### PR TITLE
[nitter] Add Media Gallery to Details View

### DIFF
--- a/app/lib/utils/fd_icons.dart
+++ b/app/lib/utils/fd_icons.dart
@@ -13,6 +13,7 @@
 ///
 ///
 ///
+
 import 'package:flutter/widgets.dart';
 
 class FDIcons {

--- a/app/lib/widgets/item/details/item_details_nitter.dart
+++ b/app/lib/widgets/item/details/item_details_nitter.dart
@@ -2,7 +2,9 @@ import 'package:flutter/material.dart';
 
 import 'package:feeddeck/models/item.dart';
 import 'package:feeddeck/models/source.dart';
+import 'package:feeddeck/utils/constants.dart';
 import 'package:feeddeck/widgets/item/details/utils/item_description.dart';
+import 'package:feeddeck/widgets/item/details/utils/item_media_gallery.dart';
 import 'package:feeddeck/widgets/item/details/utils/item_subtitle.dart';
 import 'package:feeddeck/widgets/item/details/utils/item_title.dart';
 
@@ -33,6 +35,17 @@ class ItemDetailsNitter extends StatelessWidget {
           itemDescription: item.description,
           sourceFormat: DescriptionFormat.html,
           tagetFormat: DescriptionFormat.markdown,
+          disableImages: true,
+        ),
+        const SizedBox(
+          height: Constants.spacingExtraSmall,
+        ),
+        ItemMediaGallery(
+          itemMedias: item.options != null && item.options!.containsKey('media')
+              ? (item.options!['media'] as List)
+                  .map((item) => item as String)
+                  .toList()
+              : null,
         ),
       ],
     );

--- a/app/lib/widgets/item/details/utils/item_description.dart
+++ b/app/lib/widgets/item/details/utils/item_description.dart
@@ -27,11 +27,13 @@ class ItemDescription extends StatelessWidget {
     required this.itemDescription,
     required this.sourceFormat,
     required this.tagetFormat,
+    this.disableImages,
   });
 
   final String? itemDescription;
   final DescriptionFormat sourceFormat;
   final DescriptionFormat tagetFormat;
+  final bool? disableImages;
 
   /// [_openUrl] opens the item url in the default browser of the current
   /// device.
@@ -61,6 +63,10 @@ class ItemDescription extends StatelessWidget {
         }
       },
       imageBuilder: (uri, title, alt) {
+        if (disableImages == true) {
+          return Container();
+        }
+
         String imageUrl = uri.toString();
         if (kIsWeb) {
           imageUrl =


### PR DESCRIPTION
Instead of rendering the images for a Nitter item within the description in the details view, we are now rendering the images via the "ItemMediaGallery" widget. To not render the images twice, we also added the "disableImages" paramter to the "ItemDescription" widget, to not render the images in the widget.