### PR TITLE
[core] Add Continuous Delivery and Release Workflow

### DIFF
--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -1,0 +1,29 @@
+name-template: "$RESOLVED_VERSION"
+tag-template: "$RESOLVED_VERSION"
+version-template: "v$MAJOR.$MINOR.$PATCH"
+categories:
+  - title: "Added"
+    labels:
+      - "changelog: added"
+  - title: "Fixed"
+    labels:
+      - "changelog: fixed"
+  - title: "Changed"
+    labels:
+      - "changelog: changed"
+version-resolver:
+  minor:
+    labels:
+      - "changelog: added"
+      - "changelog: changed"
+  patch:
+    labels:
+      - "changelog: fixed"
+  default: patch
+category-template: "### $TITLE"
+change-template: '- #$NUMBER: $TITLE @$AUTHOR'
+template: |
+  $CHANGES
+replacers:
+  - search: ':warning:'
+    replace: ':warning: _Breaking change:_ :warning:'

--- a/.github/workflows/continuous-delivery.yaml
+++ b/.github/workflows/continuous-delivery.yaml
@@ -1,0 +1,54 @@
+name: Continuous Delivery
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - v*
+
+jobs:
+  docker:
+    name: Docker
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set Docker Tag
+        id: tag
+        run: |
+          if [[ $GITHUB_REF == refs/tags/* ]]; then
+            echo TAG=${GITHUB_REF:10} >> $GITHUB_ENV
+          else
+            echo TAG=main >> $GITHUB_ENV
+          fi
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: ghcr.io
+
+      - name: Build and Push Docker Image
+        id: docker_build
+        uses: docker/build-push-action@v4
+        with:
+          push: true
+          context: ./supabase/functions
+          file: ./supabase/functions/_cmd/Dockerfile
+          platforms: linux/amd64,linux/arm64/v8
+          tags: ghcr.io/${{ github.repository_owner }}/feeddeck:${{ env.TAG }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,26 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  changelog:
+    name: Changelog
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Update Changelog
+        uses: release-drafter/release-drafter@v5
+        with:
+          config-name: release.yaml
+          disable-autolabeler: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Add a continuous delivery and release workflow. The continuous delivery workflow is used to build the Docker image for FeedDeck and the release workflow is used to generate the changelog.