### PR TITLE
[core] Add Continuous Delivery for Desktop Apps

### DIFF
--- a/.github/workflows/continuous-delivery.yaml
+++ b/.github/workflows/continuous-delivery.yaml
@@ -6,11 +6,18 @@ on:
       - main
     tags:
       - v*
+  pull_request:
+  release:
+    types:
+      - published
 
 jobs:
+  # The "Docker" job builds the Docker image and pushes it to the GitHub Container Registry. The job only runs when a
+  # commit is pushed to the main branch or a new tag is created.
   docker:
     name: Docker
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
     permissions:
       contents: read
       packages: write
@@ -53,14 +60,17 @@ jobs:
           platforms: linux/amd64,linux/arm64/v8
           tags: ghcr.io/${{ github.repository_owner }}/feeddeck:${{ env.TAG }}
 
+  # The "Web" job builds the Flutter web app and publishes it to Cloudflare Pages. The job only runs when a commit is
+  # pushed to the main branch or a new tag is created.
   web:
     name: Web
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: "app"
-    permissions:
-      contents: read
 
     steps:
       - name: Checkout
@@ -119,3 +129,172 @@ jobs:
           projectName: ${{ env.CLOUDFLARE_PROJECT_NAME }}
           directory: ./app/build/web
           branch: main
+
+  # The "macOS" job builds the Flutter macOS app and uploads it to the GitHub release or the pull request. The job only
+  # runs for pull requests and when a new release is published.
+  macos:
+    name: macOS
+    runs-on: macos-latest
+    if: github.event_name == 'pull_request' || (github.event_name == 'release' && github.event.action == 'published')
+    permissions:
+      contents: read
+    defaults:
+      run:
+        working-directory: "app"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.7.12'
+          channel: 'stable'
+          cache: true
+          cache-key: 'flutter-:os:-:channel:-:version:-:arch:-:hash:'
+          cache-path: '${{ runner.tool_cache }}/flutter/:channel:-:version:-:arch:'
+
+      - name: Install Dependencies
+        run: |
+          flutter pub get
+
+      - name: Build
+        run: |
+          flutter config --enable-macos-desktop
+          flutter build macos --release --dart-define SUPABASE_URL=${{ secrets.SUPABASE_PROD_URL }} --dart-define SUPABASE_ANON_KEY=${{ secrets.SUPABASE_PROD_ANON_KEY }} --dart-define SUPABASE_SITE_URL=${{ secrets.SUPABASE_PROD_SITE_URL }} --dart-define GOOGLE_CLIENT_ID=${{ secrets.SUPABASE_PROD_GOOGLE_CLIENT_ID }}
+
+      - name: Package
+        run: |
+          ditto -c -k --keepParent "build/macos/Build/Products/Release/FeedDeck.app" "build/macos/Build/Products/Release/feeddeck-macos-universal.zip"
+
+      - name: Upload Artifacts (PR)
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: feeddeck-macos-universal.zip
+          path: app/build/macos/Build/Products/Release/feeddeck-macos-universal.zip
+          if-no-files-found: error
+
+      - name: Upload Artifacts (Release)
+        uses: shogo82148/actions-upload-release-asset@v1
+        if: ${{ github.event_name == 'release' && github.event.action == 'published' }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: app/build/macos/Build/Products/Release/feeddeck-macos-universal.zip
+
+  # The "Linux" job builds the Flutter Linux app and uploads it to the GitHub release or the pull request. The job only
+  # runs for pull requests and when a new release is published.
+  linux:
+    name: Linux
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' || (github.event_name == 'release' && github.event.action == 'published')
+    permissions:
+      contents: read
+    defaults:
+      run:
+        working-directory: "app"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install Packages
+        run: |
+          # Required for Flutter
+          sudo apt-get update -y
+          sudo apt-get install -y ninja-build libgtk-3-dev
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.7.12'
+          channel: 'stable'
+          cache: true
+          cache-key: 'flutter-:os:-:channel:-:version:-:arch:-:hash:'
+          cache-path: '${{ runner.tool_cache }}/flutter/:channel:-:version:-:arch:'
+
+      - name: Install Dependencies
+        run: |
+          flutter pub get
+
+      - name: Build
+        run: |
+          flutter config --enable-linux-desktop
+          flutter build linux --release --dart-define SUPABASE_URL=${{ secrets.SUPABASE_PROD_URL }} --dart-define SUPABASE_ANON_KEY=${{ secrets.SUPABASE_PROD_ANON_KEY }} --dart-define SUPABASE_SITE_URL=${{ secrets.SUPABASE_PROD_SITE_URL }} --dart-define GOOGLE_CLIENT_ID=${{ secrets.SUPABASE_PROD_GOOGLE_CLIENT_ID }}
+
+      - name: Package
+        run: |
+          cd build
+          cp -r linux/x64/release/bundle/ feeddeck-linux-x86_64
+          tar -czf feeddeck-linux-x86_64.tar.gz feeddeck-linux-x86_64
+
+      - name: Upload Artifacts (PR)
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: feeddeck-linux-x86_64.tar.gz
+          path: app/build/feeddeck-linux-x86_64.tar.gz
+          if-no-files-found: error
+
+      - name: Upload Artifacts (Release)
+        uses: shogo82148/actions-upload-release-asset@v1
+        if: ${{ github.event_name == 'release' && github.event.action == 'published' }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: app/build/feeddeck-linux-x86_64.tar.gz
+
+  # The "Windows" job builds the Flutter Windows app and uploads it to the GitHub release or the pull request. The job
+  # only runs for pull requests and when a new release is published.
+  windows:
+    name: Windows
+    runs-on: windows-latest
+    if: github.event_name == 'pull_request' || (github.event_name == 'release' && github.event.action == 'published')
+    permissions:
+      contents: read
+    defaults:
+      run:
+        working-directory: "app"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.7.12'
+          channel: 'stable'
+          cache: true
+          cache-key: 'flutter-:os:-:channel:-:version:-:arch:-:hash:'
+          cache-path: '${{ runner.tool_cache }}/flutter/:channel:-:version:-:arch:'
+
+      - name: Install Dependencies
+        run: |
+          flutter pub get
+
+      - name: Build
+        run: |
+          flutter config --enable-windows-desktop
+          flutter build windows --release --dart-define SUPABASE_URL=${{ secrets.SUPABASE_PROD_URL }} --dart-define SUPABASE_ANON_KEY=${{ secrets.SUPABASE_PROD_ANON_KEY }} --dart-define SUPABASE_SITE_URL=${{ secrets.SUPABASE_PROD_SITE_URL }} --dart-define GOOGLE_CLIENT_ID=${{ secrets.SUPABASE_PROD_GOOGLE_CLIENT_ID }}
+
+      - name: Package
+        run: |
+          flutter pub run msix:create --output-path build --output-name feeddeck
+          cd build
+          7z a -tzip feeddeck-windows-x86_64.zip feeddeck.msix
+
+      - name: Upload Artifacts (PR)
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: feeddeck-windows-x86_64.zip
+          path: app/build/feeddeck-windows-x86_64.zip
+          if-no-files-found: error
+
+      - name: Upload Artifacts (Release)
+        uses: shogo82148/actions-upload-release-asset@v1
+        if: ${{ github.event_name == 'release' && github.event.action == 'published' }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: app/build/feeddeck-windows-x86_64.zip

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -145,6 +145,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.17.0"
+  console:
+    dependency: transitive
+    description:
+      name: console
+      sha256: e04e7824384c5b39389acdd6dc7d33f3efe6b232f6f16d7626f194f6a01ad69a
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.0"
   convert:
     dependency: transitive
     description:
@@ -280,6 +288,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.2"
+  get_it:
+    dependency: transitive
+    description:
+      name: get_it
+      sha256: "529de303c739fca98cd7ece5fca500d8ff89649f1bb4b4e94fb20954abcd7468"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.6.0"
   gotrue:
     dependency: transitive
     description:
@@ -488,6 +504,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.0.1"
+  msix:
+    dependency: "direct dev"
+    description:
+      name: msix
+      sha256: "76c87b8207323803169626a55afd78bbb8413c984df349a76598b9fbf9224677"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.16.1"
   nested:
     dependency: transitive
     description:
@@ -504,6 +528,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.2"
+  package_config:
+    dependency: transitive
+    description:
+      name: package_config
+      sha256: "1c5b77ccc91e4823a5af61ee74e6b972db1ef98c2ff5a18d3161c982a55448bd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   path:
     dependency: transitive
     description:
@@ -624,6 +656,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.5"
+  pub_semver:
+    dependency: transitive
+    description:
+      name: pub_semver
+      sha256: "40d3ab1bbd474c4c2328c91e3a7df8c6dd629b79ece4c4bd04bee496a224fb0c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.4"
   realtime_client:
     dependency: transitive
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -1,5 +1,5 @@
 name: feeddeck
-description: A new Flutter project.
+description: Follow your RSS and Social Media Feeds
 # The following line prevents the package from being accidentally published to
 # pub.dev using `flutter pub publish`. This is preferred for private packages.
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.0+1
+version: 0.1.0+1
 
 environment:
   sdk: '>=2.19.6 <3.0.0'
@@ -72,6 +72,7 @@ dev_dependencies:
 
   flutter_launcher_icons: ^0.13.1
   import_sorter: ^4.6.0
+  msix: ^3.16.1
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec
@@ -148,3 +149,22 @@ flutter_native_splash:
     color: "#49d3b4"
     icon_background_color: "#49d3b4"
   fullscreen: true
+
+# The following section specifies the settings for the "msix" package, to build
+# an MSIX package for Windows which can be distributed via the Windows app
+# store, see https://pub.dev/packages/msix
+msix_config:
+  # MSIX Configuration
+  display_name: FeedDeck
+  publisher_display_name: Rico Berger
+  identity_name: 26077RicoBerger.FeedDeck
+  publisher: CN=7740451A-C179-450A-B346-7231CA231332
+  msix_version: 0.1.0.1
+  languages: en-us
+  capabilities: internetClient
+  protocol_activation: http,https
+  execution_alias: feeddeck
+  store: true
+  install_certificate: false
+  # Build Configuration
+  build_windows: false


### PR DESCRIPTION
Add continuous delivery workflows for the desktop apps. While we want to provide the desktop versions of FeedDeck though the different app stores we still want to build them via GitHub Actions, so users can also test the desktop apps before an official release.

This is also useful to build the binaries we can then download and upload to the official stores, since we currently only have a macOS system to build the apps.