### PR TITLE
[core] Add Info Section to Settings

### DIFF
--- a/app/lib/widgets/settings/profile/settings_profile.dart
+++ b/app/lib/widgets/settings/profile/settings_profile.dart
@@ -44,6 +44,9 @@ class _SettingsProfileState extends State<SettingsProfile> {
         SettingsProfileOpenWebApp(),
         SettingsProfileSignOut(),
         SettingsProfileDeleteAccount(),
+        SizedBox(
+          height: Constants.spacingMiddle,
+        ),
       ],
     );
   }

--- a/app/lib/widgets/settings/settings.dart
+++ b/app/lib/widgets/settings/settings.dart
@@ -7,6 +7,7 @@ import 'package:feeddeck/utils/constants.dart';
 import 'package:feeddeck/widgets/settings/accounts/settings_accounts.dart';
 import 'package:feeddeck/widgets/settings/decks/settings_decks.dart';
 import 'package:feeddeck/widgets/settings/profile/settings_profile.dart';
+import 'package:feeddeck/widgets/settings/settings_info.dart';
 import 'package:feeddeck/widgets/settings/settings_payment_banner.dart';
 
 /// The [Settings] widget implements the settings page for the FeedDeck app. The
@@ -73,6 +74,10 @@ class _SettingsState extends State<Settings> {
                     /// user can update his email address and password or delete
                     /// his account.
                     SettingsProfile(),
+
+                    /// Display some general information about the app, like the
+                    /// version and the link to our website.
+                    SettingsInfo(),
                   ],
                 ),
               ),

--- a/app/lib/widgets/settings/settings_info.dart
+++ b/app/lib/widgets/settings/settings_info.dart
@@ -1,0 +1,163 @@
+import 'package:flutter/material.dart';
+
+import 'package:package_info_plus/package_info_plus.dart';
+
+import 'package:feeddeck/utils/constants.dart';
+import 'package:feeddeck/utils/fd_icons.dart';
+import 'package:feeddeck/utils/openurl.dart';
+
+/// The [SettingsInfo] widget implements the info section of the settings page.
+/// Here the user can find information the version of the app and the links to
+/// the website, the GitHub repository and the X account.
+class SettingsInfo extends StatefulWidget {
+  const SettingsInfo({Key? key}) : super(key: key);
+
+  @override
+  State<SettingsInfo> createState() => _SettingsInfoState();
+}
+
+class _SettingsInfoState extends State<SettingsInfo> {
+  String _version = '';
+
+  /// [_getVersion] sets the [_version] variable via the [PackageInfo] package.
+  /// The [_version] is then displayed within the information items. When we are
+  /// not able to get the version of the app we log an error and leave the
+  /// version unset.
+  Future<void> _getVersion() async {
+    try {
+      PackageInfo packageInfo = await PackageInfo.fromPlatform();
+      setState(() {
+        _version = packageInfo.version;
+      });
+    } catch (_) {}
+  }
+
+  /// [_buildItem] returns a single information item. The item contains a title,
+  /// an icon and an onTap function. The onTap function is called when the user
+  /// clicks on the item.
+  Widget _buildItem(String title, Widget icon, void Function()? onTap) {
+    return MouseRegion(
+      cursor: SystemMouseCursors.click,
+      child: GestureDetector(
+        onTap: onTap,
+        child: Card(
+          color: Constants.secondary,
+          margin: const EdgeInsets.only(
+            bottom: Constants.spacingSmall,
+          ),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(12),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Padding(
+                padding: const EdgeInsets.all(
+                  Constants.spacingMiddle,
+                ),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            Characters(
+                              title,
+                            )
+                                .replaceAll(
+                                  Characters(''),
+                                  Characters('\u{200B}'),
+                                )
+                                .toString(),
+                            maxLines: 1,
+                            style: const TextStyle(
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                    icon,
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _getVersion();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text(
+          'Info',
+          style: TextStyle(
+            fontSize: 20.0,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        const SizedBox(
+          height: Constants.spacingSmall,
+        ),
+        _buildItem(
+          'Version',
+          Container(
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(6),
+              color: Constants.primary,
+            ),
+            padding: const EdgeInsets.all(
+              Constants.spacingExtraSmall,
+            ),
+            child: Text(
+              _version,
+              style: const TextStyle(
+                color: Constants.onPrimary,
+              ),
+            ),
+          ),
+          null,
+        ),
+        _buildItem(
+          'Website',
+          const Icon(FDIcons.browser),
+          () {
+            try {
+              openUrl('https://feeddeck.app');
+            } catch (_) {}
+          },
+        ),
+        _buildItem(
+          'GitHub',
+          const Icon(FDIcons.github),
+          () {
+            try {
+              openUrl('https://github.com/feeddeck/feeddeck');
+            } catch (_) {}
+          },
+        ),
+        _buildItem(
+          'X',
+          const Icon(FDIcons.x),
+          () {
+            try {
+              openUrl('https://x.com/feeddeckapp');
+            } catch (_) {}
+          },
+        ),
+      ],
+    );
+  }
+}

--- a/app/lib/widgets/settings/settings_payment_banner.dart
+++ b/app/lib/widgets/settings/settings_payment_banner.dart
@@ -95,7 +95,7 @@ class SettingsPaymentBanner extends StatelessWidget {
                           height: Constants.spacingSmall,
                         ),
                         Text(
-                          'FeedDeck Premium',
+                          'Subscribe to FeedDeck Premium',
                           textAlign: TextAlign.center,
                           style: TextStyle(
                             fontSize: 20,
@@ -177,7 +177,7 @@ class _SettingsPaymentBannerModalState
             width: 1,
           ),
         ),
-        title: const Text('FeedDeck Premium'),
+        title: const Text('Subscribe to FeedDeck Premium'),
         actions: [
           IconButton(
             icon: const Icon(

--- a/app/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/app/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -9,6 +9,7 @@ import app_links
 import audio_service
 import audio_session
 import just_audio
+import package_info_plus
 import path_provider_foundation
 import screen_retriever
 import shared_preferences_foundation
@@ -22,6 +23,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AudioServicePlugin.register(with: registry.registrar(forPlugin: "AudioServicePlugin"))
   AudioSessionPlugin.register(with: registry.registrar(forPlugin: "AudioSessionPlugin"))
   JustAudioPlugin.register(with: registry.registrar(forPlugin: "JustAudioPlugin"))
+  FLTPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FLTPackageInfoPlusPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   ScreenRetrieverPlugin.register(with: registry.registrar(forPlugin: "ScreenRetrieverPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -536,6 +536,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
+  package_info_plus:
+    dependency: "direct main"
+    description:
+      name: package_info_plus
+      sha256: "6ff267fcd9d48cb61c8df74a82680e8b82e940231bb5f68356672fde0397334a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.0"
+  package_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: package_info_plus_platform_interface
+      sha256: "9bc8ba46813a4cc42c66ab781470711781940780fd8beddd0c3da62506d3a6c6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   path:
     dependency: transitive
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -49,6 +49,7 @@ dependencies:
   just_audio_background: ^0.0.1-beta.10
   just_audio_windows: ^0.2.0
   just_audio_mpv: ^0.1.6
+  package_info_plus: ^4.1.0
   provider: ^6.0.4
   rxdart: ^0.27.7
   scroll_to_index: ^3.0.1


### PR DESCRIPTION
The settings page now contains an info section, which is used to show the current app version via the "package_info_plus" package, the link to our website, the link to our GitHub repository and the link to our X account.