### PR TITLE
[core] Fix Continuous Delivery for Supabase

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -397,11 +397,17 @@ Android, macOS, Windows and Linux if you do not want to use the official ones.
 
 ## Release
 
+```sh
+supabase link --project-ref <PROJECT-ID>
+supabase secrets set --env-file supabase/.env.prod
+supabase secrets list
+```
+
 ### Web
 
 To create a new release for the web version, the following workflow can be used:
 
-1. Delete the build/ and .dart_tool/ directories: `flutter clean`
+1. Delete the `build/` and `.dart_tool/` directories: `flutter clean`
 
 2. Build a web application bundle:
    `flutter build web --dart-define SUPABASE_URL=<SUPABASE_URL> --dart-define SUPABASE_ANON_KEY=<SUPABASE_ANON_KEY> --dart-define SUPABASE_SITE_URL=<SUPABASE_SITE_URL> --dart-define GOOGLE_CLIENT_ID=<GOOGLE_CLIENT_ID>`

--- a/supabase/functions/import_map.json
+++ b/supabase/functions/import_map.json
@@ -9,6 +9,6 @@
     "cheerio": "https://esm.sh/cheerio@1.0.0-rc.12",
     "lodash": "https://raw.githubusercontent.com/lodash/lodash/4.17.21-es/lodash.js",
     "redis": "https://deno.land/x/redis@v0.29.4/mod.ts",
-    "stripe": "https://esm.sh/stripe@12.9.0?target=deno"
+    "stripe": "https://esm.sh/stripe@12.9.0?target=deno&no-check"
   }
 }


### PR DESCRIPTION
The continuous delivery GitHub Action workflow to run the database migration and to deploy the functions, runs in to the following error:

```
error: Uncaught (in promise) Error: Relative import path "http" not prefixed with / or ./ or ../ and not in import map from "https://esm.sh/v132/@types/node@18.16.19/http.d.ts"
      const ret = new Error(getStringFromWasm0(arg0, arg1));
```

See https://github.com/feeddeck/feeddeck/actions/runs/6199706506/job/16832826456#logs