### PR TITLE
[rss] Allow RSS Feeds without "published" Field

### DIFF
--- a/supabase/functions/_shared/feed/rss.ts
+++ b/supabase/functions/_shared/feed/rss.ts
@@ -113,7 +113,8 @@ export const getRSSFeed = async (
      */
     if (
       !entry.title?.value ||
-      (entry.links.length === 0 || !entry.links[0].href) || !entry.published
+      (entry.links.length === 0 || !entry.links[0].href) ||
+      (!entry.published && !entry.updated)
     ) {
       continue;
     }
@@ -143,7 +144,11 @@ export const getRSSFeed = async (
       media: getMedia(entry),
       description: getItemDescription(entry),
       author: entry.author?.name,
-      publishedAt: Math.floor(entry.published.getTime() / 1000),
+      publishedAt: entry.published
+        ? Math.floor(entry.published.getTime() / 1000)
+        : entry.updated
+        ? Math.floor(entry.updated.getTime() / 1000)
+        : Math.floor(new Date().getTime() / 1000),
     });
   }
 


### PR DESCRIPTION
If a RSS feed entry did not contain a "published" field, we skipped the entry and didn't added it to the database. Now it is also possible to use feeds without a "published" field. If a feed entry does not contain the field it must contain a "updated" field, which we then use for the "publishedAt" field in the database. If a feed entry doesn't contain one of the two fields the entry is still skipped.

<!--
  Keep PR title verbose enough and add prefix telling about what source it touches e.g "[rss] Add feature xyz" or if the
  the PR is not realated to a source use "[core]", e.g. "[core] Fix xyz".

  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
