### PR TITLE
[nitter] Allow Usage of Custom Nitter Instances

### DIFF
--- a/app/lib/widgets/source/add/add_source_nitter.dart
+++ b/app/lib/widgets/source/add/add_source_nitter.dart
@@ -14,8 +14,11 @@ import 'package:feeddeck/widgets/source/add/add_source_form.dart';
 const _helpText = '''
 The Nitter source can be used to add an RSS feed for Nitter:
 
+- **RSS Feed**: `https://nitter.net/rico_berger/rss` or `https://nitter.net/search/rss?f=tweets&q=FeedDeck`
 - **Username**: `@rico_berger`
 - **Search Term**: `FeedDeck`
+
+**Note:** We recommend that you use your own Nitter instance to avoid rate limiting.
 ''';
 
 /// The [AddSourceNitter] widget is used to display the form to add a new Nitter


### PR DESCRIPTION
It is now possible to use a custom Nitter instances. This means a user must not rely on our Nitter instance and can instead use his own instance. To use a custom Nitter instance a user must provide the full RSS feed url for the instance.

<!--
  Keep PR title verbose enough and add prefix telling about what source it touches e.g "[rss] Add feature xyz" or if the
  the PR is not realated to a source use "[core]", e.g. "[core] Fix xyz".

  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
