### PR TITLE
[youtube] Add Missing URL in isYoutubeUrl Function

### DIFF
--- a/supabase/functions/_shared/feed/youtube.ts
+++ b/supabase/functions/_shared/feed/youtube.ts
@@ -19,7 +19,8 @@ import { log } from "../utils/log.ts";
  */
 export const isYoutubeUrl = (url: string): boolean => {
   return url.startsWith("https://www.youtube.com/") ||
-    url.startsWith("https://m.youtube.com/");
+    url.startsWith("https://m.youtube.com/") ||
+    url.startsWith("https://youtube.com/");
 };
 
 export const getYoutubeFeed = async (


### PR DESCRIPTION
In the "isYoutubeUrl" function we are checking if the provided url is related to YouTube. For that we checked if the url starts with "https://www.youtube.com/" or "https://m.youtube.com/", but we also have to check if the url starts with "https://youtube.com/" which is used when a users shares a link to a channel via the YouTube app.

In this commit we add the missing "https://youtube.com/" option to the "isYoutubeUrl" function.

<!--
  Keep PR title verbose enough and add prefix telling about what source it touches e.g "[rss] Add feature xyz" or if the
  the PR is not realated to a source use "[core]", e.g. "[core] Fix xyz".

  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
