### PR TITLE
[core] Use Published Date for Item Ingestion

### DIFF
--- a/supabase/functions/_shared/feed/mastodon.ts
+++ b/supabase/functions/_shared/feed/mastodon.ts
@@ -89,22 +89,12 @@ export const getMastodonFeed = async (
 
   /**
    * Now that the source does contain all the required information we can start to generate the items for the source, by
-   * looping over all the feed entries. We only add the first 50 items from the feed, because we only keep the latest 50
-   * items for each source in our deletion logic.
+   * looping over all the feed entries.
    */
   const items: IItem[] = [];
 
   for (const [index, entry] of feed.entries.entries()) {
-    if (index === 50) {
-      break;
-    }
-
-    /**
-     * If the entry does not contain a title, a link or a published date we skip it.
-     */
-    if (
-      (entry.links.length === 0 || !entry.links[0].href) || !entry.published
-    ) {
+    if (skipEntry(index, entry, source.updatedAt || 0)) {
       continue;
     }
 
@@ -135,17 +125,45 @@ export const getMastodonFeed = async (
       columnId: source.columnId,
       sourceId: source.id,
       title: "",
-      link: entry.links[0].href,
+      link: entry.links[0].href!,
       options: media && media.length > 0 ? { media: media } : undefined,
       description: entry.description?.value
         ? unescape(entry.description.value)
         : undefined,
       author: getAuthor(entry),
-      publishedAt: Math.floor(entry.published.getTime() / 1000),
+      publishedAt: Math.floor(entry.published!.getTime() / 1000),
     });
   }
 
   return { source, items };
+};
+
+/**
+ * `skipEntry` is used to determin if an entry should be skipped or not. When a entry in the RSS feed is skipped it will
+ * not be added to the database. An entry will be skipped when
+ * - it is not within the first 50 entries of the feed, because we only keep the last 50 items of each source in our
+ *   delete logic.
+ * - the entry does not contain a link or a published date.
+ * - the published date of the entry is older than the last update date of the source minus 10 seconds.
+ */
+const skipEntry = (
+  index: number,
+  entry: FeedEntry,
+  sourceUpdatedAt: number,
+): boolean => {
+  if (index === 50) {
+    return true;
+  }
+
+  if ((entry.links.length === 0 || !entry.links[0].href) || !entry.published) {
+    return true;
+  }
+
+  if (Math.floor(entry.published.getTime() / 1000) <= (sourceUpdatedAt - 10)) {
+    return true;
+  }
+
+  return false;
 };
 
 /**

--- a/supabase/functions/_shared/feed/medium.ts
+++ b/supabase/functions/_shared/feed/medium.ts
@@ -118,23 +118,12 @@ export const getMediumFeed = async (
 
   /**
    * Now that the source does contain all the required information we can start to generate the items for the source, by
-   * looping over all the feed entries. We only add the first 50 items from the feed, because we only keep the latest 50
-   * items for each source in our deletion logic.
+   * looping over all the feed entries.
    */
   const items: IItem[] = [];
 
   for (const [index, entry] of feed.entries.entries()) {
-    if (index === 50) {
-      break;
-    }
-
-    /**
-     * If the entry does not contain a title, a link or a published date we skip it.
-     */
-    if (
-      !entry.title?.value ||
-      (entry.links.length === 0 || !entry.links[0].href) || !entry.published
-    ) {
+    if (skipEntry(index, entry, source.updatedAt || 0)) {
       continue;
     }
 
@@ -160,16 +149,47 @@ export const getMediumFeed = async (
       userId: source.userId,
       columnId: source.columnId,
       sourceId: source.id,
-      title: entry.title.value,
-      link: entry.links[0].href,
+      title: entry.title!.value!,
+      link: entry.links[0].href!,
       media: getMedia(entry),
       description: getItemDescription(entry),
       author: entry["dc:creator"]?.join(", "),
-      publishedAt: Math.floor(entry.published.getTime() / 1000),
+      publishedAt: Math.floor(entry.published!.getTime() / 1000),
     });
   }
 
   return { source, items };
+};
+
+/**
+ * `skipEntry` is used to determin if an entry should be skipped or not. When a entry in the RSS feed is skipped it will
+ * not be added to the database. An entry will be skipped when
+ * - it is not within the first 50 entries of the feed, because we only keep the last 50 items of each source in our
+ *   delete logic.
+ * - the entry does not contain a title, a link or a published date.
+ * - the published date of the entry is older than the last update date of the source minus 10 seconds.
+ */
+const skipEntry = (
+  index: number,
+  entry: FeedEntry,
+  sourceUpdatedAt: number,
+): boolean => {
+  if (index === 50) {
+    return true;
+  }
+
+  if (
+    !entry.title?.value ||
+    (entry.links.length === 0 || !entry.links[0].href) || !entry.published
+  ) {
+    return true;
+  }
+
+  if (Math.floor(entry.published.getTime() / 1000) <= (sourceUpdatedAt - 10)) {
+    return true;
+  }
+
+  return false;
 };
 
 /**

--- a/supabase/functions/_shared/feed/nitter.ts
+++ b/supabase/functions/_shared/feed/nitter.ts
@@ -83,23 +83,12 @@ export const getNitterFeed = async (
 
   /**
    * Now that the source does contain all the required information we can start to generate the items for the source, by
-   * looping over all the feed entries. We only add the first 50 items from the feed, because we only keep the latest 50
-   * items for each source in our deletion logic.
+   * looping over all the feed entries.
    */
   const items: IItem[] = [];
 
   for (const [index, entry] of feed.entries.entries()) {
-    if (index === 50) {
-      break;
-    }
-
-    /**
-     * If the entry does not contain a title, a link or a published date we skip it.
-     */
-    if (
-      !entry.title?.value ||
-      (entry.links.length === 0 || !entry.links[0].href) || !entry.published
-    ) {
+    if (skipEntry(index, entry, source.updatedAt || 0)) {
       continue;
     }
 
@@ -129,18 +118,49 @@ export const getNitterFeed = async (
       userId: source.userId,
       columnId: source.columnId,
       sourceId: source.id,
-      title: entry.title.value,
-      link: entry.links[0].href,
+      title: entry.title!.value!,
+      link: entry.links[0].href!,
       options: media && media.length > 0 ? { media: media } : undefined,
       description: entry.description?.value
         ? unescape(entry.description.value)
         : undefined,
       author: entry["dc:creator"]?.join(", "),
-      publishedAt: Math.floor(entry.published.getTime() / 1000),
+      publishedAt: Math.floor(entry.published!.getTime() / 1000),
     });
   }
 
   return { source, items };
+};
+
+/**
+ * `skipEntry` is used to determin if an entry should be skipped or not. When a entry in the RSS feed is skipped it will
+ * not be added to the database. An entry will be skipped when
+ * - it is not within the first 50 entries of the feed, because we only keep the last 50 items of each source in our
+ *   delete logic.
+ * - the entry does not contain a title, a link or a published date.
+ * - the published date of the entry is older than the last update date of the source minus 10 seconds.
+ */
+const skipEntry = (
+  index: number,
+  entry: FeedEntry,
+  sourceUpdatedAt: number,
+): boolean => {
+  if (index === 50) {
+    return true;
+  }
+
+  if (
+    !entry.title?.value ||
+    (entry.links.length === 0 || !entry.links[0].href) || !entry.published
+  ) {
+    return true;
+  }
+
+  if (Math.floor(entry.published.getTime() / 1000) <= (sourceUpdatedAt - 10)) {
+    return true;
+  }
+
+  return false;
 };
 
 /**

--- a/supabase/functions/_shared/feed/reddit.ts
+++ b/supabase/functions/_shared/feed/reddit.ts
@@ -79,23 +79,12 @@ export const getRedditFeed = async (
 
   /**
    * Now that the source does contain all the required information we can start to generate the items for the source, by
-   * looping over all the feed entries. We only add the first 50 items from the feed, because we only keep the latest 50
-   * items for each source in our deletion logic.
+   * looping over all the feed entries.
    */
   const items: IItem[] = [];
 
   for (const [index, entry] of feed.entries.entries()) {
-    if (index === 50) {
-      break;
-    }
-
-    /**
-     * If the entry does not contain a title, a link or a published date we skip it.
-     */
-    if (
-      !entry.title?.value ||
-      (entry.links.length === 0 || !entry.links[0].href) || !entry.published
-    ) {
+    if (skipEntry(index, entry, source.updatedAt || 0)) {
       continue;
     }
 
@@ -121,18 +110,49 @@ export const getRedditFeed = async (
       userId: source.userId,
       columnId: source.columnId,
       sourceId: source.id,
-      title: entry.title.value,
-      link: entry.links[0].href,
+      title: entry.title!.value!,
+      link: entry.links[0].href!,
       media: getMedia(entry),
       description: entry.content?.value
         ? unescape(entry.content.value)
         : undefined,
       author: entry.author?.name,
-      publishedAt: Math.floor(entry.published.getTime() / 1000),
+      publishedAt: Math.floor(entry.published!.getTime() / 1000),
     });
   }
 
   return { source, items };
+};
+
+/**
+ * `skipEntry` is used to determin if an entry should be skipped or not. When a entry in the RSS feed is skipped it will
+ * not be added to the database. An entry will be skipped when
+ * - it is not within the first 50 entries of the feed, because we only keep the last 50 items of each source in our
+ *   delete logic.
+ * - the entry does not contain a title, a link or a published date.
+ * - the published date of the entry is older than the last update date of the source minus 10 seconds.
+ */
+const skipEntry = (
+  index: number,
+  entry: FeedEntry,
+  sourceUpdatedAt: number,
+): boolean => {
+  if (index === 50) {
+    return true;
+  }
+
+  if (
+    !entry.title?.value ||
+    (entry.links.length === 0 || !entry.links[0].href) || !entry.published
+  ) {
+    return true;
+  }
+
+  if (Math.floor(entry.published.getTime() / 1000) <= (sourceUpdatedAt - 10)) {
+    return true;
+  }
+
+  return false;
 };
 
 /**

--- a/supabase/functions/_shared/feed/stackoverflow.ts
+++ b/supabase/functions/_shared/feed/stackoverflow.ts
@@ -1,5 +1,6 @@
 import { SupabaseClient } from "@supabase/supabase-js";
 import { parseFeed } from "rss";
+import { FeedEntry } from "rss/types";
 import { Md5 } from "std/md5";
 import { Redis } from "redis";
 import { unescape } from "lodash";
@@ -67,23 +68,12 @@ export const getStackoverflowFeed = async (
 
   /**
    * Now that the source does contain all the required information we can start to generate the items for the source, by
-   * looping over all the feed entries. We only add the first 50 items from the feed, because we only keep the latest 50
-   * items for each source in our deletion logic.
+   * looping over all the feed entries.
    */
   const items: IItem[] = [];
 
   for (const [index, entry] of feed.entries.entries()) {
-    if (index === 50) {
-      break;
-    }
-
-    /**
-     * If the entry does not contain a title, a link or a published date we skip it.
-     */
-    if (
-      !entry.title?.value ||
-      (entry.links.length === 0 || !entry.links[0].href) || !entry.published
-    ) {
+    if (skipEntry(index, entry, source.updatedAt || 0)) {
       continue;
     }
 
@@ -95,18 +85,49 @@ export const getStackoverflowFeed = async (
       userId: source.userId,
       columnId: source.columnId,
       sourceId: source.id,
-      title: entry.title.value,
-      link: entry.links[0].href,
+      title: entry.title!.value!,
+      link: entry.links[0].href!,
       media: undefined,
       description: entry.description?.value
         ? unescape(entry.description.value)
         : undefined,
       author: undefined,
-      publishedAt: Math.floor(entry.published.getTime() / 1000),
+      publishedAt: Math.floor(entry.published!.getTime() / 1000),
     });
   }
 
   return { source, items };
+};
+
+/**
+ * `skipEntry` is used to determin if an entry should be skipped or not. When a entry in the RSS feed is skipped it will
+ * not be added to the database. An entry will be skipped when
+ * - it is not within the first 50 entries of the feed, because we only keep the last 50 items of each source in our
+ *   delete logic.
+ * - the entry does not contain a title, a link or a published date.
+ * - the published date of the entry is older than the last update date of the source minus 10 seconds.
+ */
+const skipEntry = (
+  index: number,
+  entry: FeedEntry,
+  sourceUpdatedAt: number,
+): boolean => {
+  if (index === 50) {
+    return true;
+  }
+
+  if (
+    !entry.title?.value ||
+    (entry.links.length === 0 || !entry.links[0].href) || !entry.published
+  ) {
+    return true;
+  }
+
+  if (Math.floor(entry.published.getTime() / 1000) <= (sourceUpdatedAt - 10)) {
+    return true;
+  }
+
+  return false;
 };
 
 /**

--- a/supabase/functions/_shared/feed/tumblr.ts
+++ b/supabase/functions/_shared/feed/tumblr.ts
@@ -84,23 +84,12 @@ export const getTumblrFeed = async (
 
   /**
    * Now that the source does contain all the required information we can start to generate the items for the source, by
-   * looping over all the feed entries. We only add the first 50 items from the feed, because we only keep the latest 50
-   * items for each source in our deletion logic.
+   * looping over all the feed entries.
    */
   const items: IItem[] = [];
 
   for (const [index, entry] of feed.entries.entries()) {
-    if (index === 50) {
-      break;
-    }
-
-    /**
-     * If the entry does not contain a title, a link or a published date we skip it.
-     */
-    if (
-      !entry.title?.value ||
-      (entry.links.length === 0 || !entry.links[0].href) || !entry.published
-    ) {
+    if (skipEntry(index, entry, source.updatedAt || 0)) {
       continue;
     }
 
@@ -112,18 +101,49 @@ export const getTumblrFeed = async (
       userId: source.userId,
       columnId: source.columnId,
       sourceId: source.id,
-      title: entry.title.value,
-      link: entry.links[0].href,
+      title: entry.title!.value!,
+      link: entry.links[0].href!,
       media: getMedia(entry),
       description: entry.description?.value
         ? unescape(entry.description?.value)
         : undefined,
       author: undefined,
-      publishedAt: Math.floor(entry.published.getTime() / 1000),
+      publishedAt: Math.floor(entry.published!.getTime() / 1000),
     });
   }
 
   return { source, items };
+};
+
+/**
+ * `skipEntry` is used to determin if an entry should be skipped or not. When a entry in the RSS feed is skipped it will
+ * not be added to the database. An entry will be skipped when
+ * - it is not within the first 50 entries of the feed, because we only keep the last 50 items of each source in our
+ *   delete logic.
+ * - the entry does not contain a title, a link or a published date.
+ * - the published date of the entry is older than the last update date of the source minus 10 seconds.
+ */
+const skipEntry = (
+  index: number,
+  entry: FeedEntry,
+  sourceUpdatedAt: number,
+): boolean => {
+  if (index === 50) {
+    return true;
+  }
+
+  if (
+    !entry.title?.value ||
+    (entry.links.length === 0 || !entry.links[0].href) || !entry.published
+  ) {
+    return true;
+  }
+
+  if (Math.floor(entry.published.getTime() / 1000) <= (sourceUpdatedAt - 10)) {
+    return true;
+  }
+
+  return false;
 };
 
 /**

--- a/supabase/functions/_shared/feed/youtube.ts
+++ b/supabase/functions/_shared/feed/youtube.ts
@@ -122,23 +122,12 @@ export const getYoutubeFeed = async (
 
   /**
    * Now that the source does contain all the required information we can start to generate the items for the source, by
-   * looping over all the feed entries. We only add the first 50 items from the feed, because we only keep the latest 50
-   * items for each source in our deletion logic.
+   * looping over all the feed entries.
    */
   const items: IItem[] = [];
 
   for (const [index, entry] of feed.entries.entries()) {
-    if (index === 50) {
-      break;
-    }
-
-    /**
-     * If the entry does not contain a title, a link or a published date we skip it.
-     */
-    if (
-      !entry.title?.value ||
-      (entry.links.length === 0 || !entry.links[0].href) || !entry.published
-    ) {
+    if (skipEntry(index, entry, source.updatedAt || 0)) {
       continue;
     }
 
@@ -165,16 +154,47 @@ export const getYoutubeFeed = async (
       userId: source.userId,
       columnId: source.columnId,
       sourceId: source.id,
-      title: entry.title.value,
-      link: entry.links[0].href,
+      title: entry.title!.value!,
+      link: entry.links[0].href!,
       media: getMedia(entry),
       description: getDescription(entry),
       author: feed.author?.name,
-      publishedAt: Math.floor(entry.published.getTime() / 1000),
+      publishedAt: Math.floor(entry.published!.getTime() / 1000),
     });
   }
 
   return { source, items };
+};
+
+/**
+ * `skipEntry` is used to determin if an entry should be skipped or not. When a entry in the RSS feed is skipped it will
+ * not be added to the database. An entry will be skipped when
+ * - it is not within the first 50 entries of the feed, because we only keep the last 50 items of each source in our
+ *   delete logic.
+ * - the entry does not contain a title, a link or a published date.
+ * - the published date of the entry is older than the last update date of the source minus 10 seconds.
+ */
+const skipEntry = (
+  index: number,
+  entry: FeedEntry,
+  sourceUpdatedAt: number,
+): boolean => {
+  if (index === 50) {
+    return true;
+  }
+
+  if (
+    !entry.title?.value ||
+    (entry.links.length === 0 || !entry.links[0].href) || !entry.published
+  ) {
+    return true;
+  }
+
+  if (Math.floor(entry.published.getTime() / 1000) <= (sourceUpdatedAt - 10)) {
+    return true;
+  }
+
+  return false;
 };
 
 /**


### PR DESCRIPTION
For the item ingestion logic we are now also looking at the published date for all entries in a RSS feed. If the published date is older then the last update date of a source the item will be skipped. This way we should reduce the number of duplicated items, where an entry was updated in the RSS feed, so that it had a new id and was written again to the database and not only updated.

<!--
  Keep PR title verbose enough and add prefix telling about what source it touches e.g "[rss] Add feature xyz" or if the
  the PR is not realated to a source use "[core]", e.g. "[core] Fix xyz".

  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
