### PR TITLE
[core] Fix Title Alignment

### DIFF
--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -149,6 +149,7 @@ class FeedDeckApp extends StatelessWidget {
             ),
             canvasColor: Constants.canvasColor,
             appBarTheme: const AppBarTheme(
+              centerTitle: true,
               backgroundColor: Constants.appBarBackgroundColor,
               scrolledUnderElevation: Constants.scrolledUnderElevation,
               elevation: Constants.appBarElevation,


### PR DESCRIPTION
When we used the AppBar widget we did not specify the "centerTitle" property, so that the title was aligned within the default of the platform. This means on iOS and macOS the title was centered, but on Android, Windows and Linux the title was aligned on the left side.

This wasn't intended and we want to have the same style on all Platforms, so that the title is now centered on all Platforms like it was already done on iOS and macOS.

<!--
  Keep PR title verbose enough and add prefix telling about what source it touches e.g "[rss] Add feature xyz" or if the
  the PR is not realated to a source use "[core]", e.g. "[core] Fix xyz".

  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
