### PR TITLE
[core] Rework Profile Edge Function

### DIFF
--- a/.github/workflows/continuous-delivery.yaml
+++ b/.github/workflows/continuous-delivery.yaml
@@ -92,10 +92,11 @@ jobs:
           supabase functions deploy generate-magic-link-v1 --project-ref $PROJECT_ID --import-map supabase/functions/import_map.json
           supabase functions deploy image-proxy-v1 --no-verify-jwt --project-ref $PROJECT_ID --import-map supabase/functions/import_map.json
           supabase functions deploy profile-v1 --project-ref $PROJECT_ID --import-map supabase/functions/import_map.json
+          supabase functions deploy profile-v2 --project-ref $PROJECT_ID --import-map supabase/functions/import_map.json
+          supabase functions deploy revenuecat-webhooks-v1 --no-verify-jwt --project-ref $PROJECT_ID --import-map supabase/functions/import_map.json
           supabase functions deploy stripe-create-billing-portal-link-v1 --project-ref $PROJECT_ID --import-map supabase/functions/import_map.json
           supabase functions deploy stripe-create-checkout-session-v1 --project-ref $PROJECT_ID --import-map supabase/functions/import_map.json
           supabase functions deploy stripe-webhooks-v1 --no-verify-jwt --project-ref $PROJECT_ID --import-map supabase/functions/import_map.json
-          supabase functions deploy revenuecat-webhooks-v1 --no-verify-jwt --project-ref $PROJECT_ID --import-map supabase/functions/import_map.json
 
       - name: Push Database Migration and Deploy Functions
         if: ${{ github.event_name == 'release' && github.event.action == 'published' }}
@@ -113,10 +114,11 @@ jobs:
           supabase functions deploy generate-magic-link-v1 --project-ref $PROJECT_ID --import-map supabase/functions/import_map.json
           supabase functions deploy image-proxy-v1 --no-verify-jwt --project-ref $PROJECT_ID --import-map supabase/functions/import_map.json
           supabase functions deploy profile-v1 --project-ref $PROJECT_ID --import-map supabase/functions/import_map.json
+          supabase functions deploy profile-v2 --project-ref $PROJECT_ID --import-map supabase/functions/import_map.json
+          supabase functions deploy revenuecat-webhooks-v1 --no-verify-jwt --project-ref $PROJECT_ID --import-map supabase/functions/import_map.json
           supabase functions deploy stripe-create-billing-portal-link-v1 --project-ref $PROJECT_ID --import-map supabase/functions/import_map.json
           supabase functions deploy stripe-create-checkout-session-v1 --project-ref $PROJECT_ID --import-map supabase/functions/import_map.json
           supabase functions deploy stripe-webhooks-v1 --no-verify-jwt --project-ref $PROJECT_ID --import-map supabase/functions/import_map.json
-          supabase functions deploy revenuecat-webhooks-v1 --no-verify-jwt --project-ref $PROJECT_ID --import-map supabase/functions/import_map.json
 
   # The "Web" job builds the Flutter web app and publishes it to Cloudflare Pages. The job only runs when a commit is
   # pushed to the main branch or a new tag is created.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -326,10 +326,11 @@ supabase functions deploy delete-user-v1 --project-ref <PROJECT-ID> --import-map
 supabase functions deploy generate-magic-link-v1 --project-ref <PROJECT-ID> --import-map supabase/functions/import_map.json
 supabase functions deploy image-proxy-v1 --no-verify-jwt --project-ref <PROJECT-ID> --import-map supabase/functions/import_map.json
 supabase functions deploy profile-v1 --project-ref <PROJECT-ID> --import-map supabase/functions/import_map.json
+supabase functions deploy profile-v2 --project-ref <PROJECT-ID> --import-map supabase/functions/import_map.json
+supabase functions deploy revenuecat-webhooks-v1 --no-verify-jwt --project-ref <PROJECT-ID> --import-map supabase/functions/import_map.json
 supabase functions deploy stripe-create-billing-portal-link-v1 --project-ref <PROJECT-ID> --import-map supabase/functions/import_map.json
 supabase functions deploy stripe-create-checkout-session-v1 --project-ref <PROJECT-ID> --import-map supabase/functions/import_map.json
 supabase functions deploy stripe-webhooks-v1 --no-verify-jwt --project-ref <PROJECT-ID> --import-map supabase/functions/import_map.json
-supabase functions deploy revenuecat-webhooks-v1 --no-verify-jwt --project-ref <PROJECT-ID> --import-map supabase/functions/import_map.json
 ```
 
 Now we have to do some manual steps to finish the setup of our Supabase project:

--- a/app/lib/widgets/settings/accounts/settings_accounts_github.dart
+++ b/app/lib/widgets/settings/accounts/settings_accounts_github.dart
@@ -35,7 +35,7 @@ class SettingsAccountsGithub extends StatelessWidget {
       await Provider.of<ProfileRepository>(
         context,
         listen: false,
-      ).deleteGithubAccount();
+      ).githubDeleteAccount();
     } catch (_) {}
   }
 
@@ -166,7 +166,7 @@ class _SettingsAccountsGithubAddState extends State<SettingsAccountsGithubAdd> {
         await Provider.of<ProfileRepository>(
           context,
           listen: false,
-        ).addGithubAccount(_tokenController.text);
+        ).githubAddAccount(_tokenController.text);
 
         setState(() {
           _isLoading = false;

--- a/supabase/functions/profile-v1/index.ts
+++ b/supabase/functions/profile-v1/index.ts
@@ -12,6 +12,9 @@ import {
   FEEDDECK_SUPABASE_URL,
 } from "../_shared/utils/constants.ts";
 
+/**
+ * DEPRECATED: This function is deprecated and will be removed in the future. Please use the new `profile-v2` function.
+ */
 serve(async (req) => {
   /**
    * We need to handle the preflight request for CORS as it is described in the Supabase documentation:

--- a/supabase/functions/profile-v2/github.ts
+++ b/supabase/functions/profile-v2/github.ts
@@ -1,0 +1,83 @@
+import { SupabaseClient, User } from "@supabase/supabase-js";
+
+import { corsHeaders } from "../_shared/utils/cors.ts";
+import { log } from "../_shared/utils/log.ts";
+import { encrypt } from "../_shared/utils/encrypt.ts";
+
+/**
+ * `githubAddAccount` adds a new GitHub account to the users profile. A user must only provide a private access token to
+ * connect his GitHub account. We encrypt the token before we store it in the database.
+ */
+export const githubAddAccount = async (
+  supabaseClient: SupabaseClient,
+  user: User,
+  data: { token?: string } | null,
+): Promise<Response> => {
+  if (!data || !data.token) {
+    return new Response(JSON.stringify({ error: "Bad Request" }), {
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+      status: 400,
+    });
+  }
+
+  const { error: updateError } = await supabaseClient.from(
+    "profiles",
+  ).update({
+    "accountGithub": { token: await encrypt(data.token) },
+  }).eq("id", user.id);
+  if (updateError) {
+    log("error", "Failed to update user profile", {
+      "user": user,
+      "error": updateError,
+    });
+    return new Response(
+      JSON.stringify({ error: "Failed to update profile" }),
+      {
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+        status: 500,
+      },
+    );
+  }
+  return new Response(
+    undefined,
+    {
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+      status: 200,
+    },
+  );
+};
+
+/**
+ * `githubDeleteAccount` deletes the users GitHub account from his profile by setting the value of the `accountGithub`
+ * column to `null`.
+ */
+export const githubDeleteAccount = async (
+  supabaseClient: SupabaseClient,
+  user: User,
+): Promise<Response> => {
+  const { error: updateError } = await supabaseClient.from(
+    "profiles",
+  ).update({
+    "accountGithub": null,
+  }).eq("id", user.id);
+  if (updateError) {
+    log("error", "Failed to update user profile", {
+      "user": user,
+      "error": updateError,
+    });
+    return new Response(
+      JSON.stringify({ error: "Failed to update profile" }),
+      {
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+        status: 500,
+      },
+    );
+  }
+  return new Response(
+    undefined,
+    {
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+      status: 200,
+    },
+  );
+};

--- a/supabase/functions/profile-v2/index.ts
+++ b/supabase/functions/profile-v2/index.ts
@@ -1,0 +1,176 @@
+import { serve } from "std/server";
+import { createClient, SupabaseClient, User } from "@supabase/supabase-js";
+
+import { corsHeaders } from "../_shared/utils/cors.ts";
+import { log } from "../_shared/utils/log.ts";
+import { IProfile } from "../_shared/models/profile.ts";
+import {
+  FEEDDECK_SUPABASE_ANON_KEY,
+  FEEDDECK_SUPABASE_SERVICE_ROLE_KEY,
+  FEEDDECK_SUPABASE_URL,
+} from "../_shared/utils/constants.ts";
+import { githubAddAccount, githubDeleteAccount } from "./github.ts";
+
+/**
+ * `getProfile` returns the users profile. The user profile contains information about the users subscription and the
+ * connected accounts.
+ *
+ * ATTENTION: We should never return the users account token. Instead we should return a boolean if the user has
+ * connected an account or not.
+ */
+const getProfile = async (
+  supabaseClient: SupabaseClient,
+  user: User,
+): Promise<Response> => {
+  const { data: profile, error: profileError } = await supabaseClient
+    .from(
+      "profiles",
+    )
+    .select("*").eq(
+      "id",
+      user.id,
+    );
+  if (profileError || profile?.length !== 1) {
+    log("error", "Failed to get user profile", {
+      "user": user,
+      "error": profileError,
+    });
+    return new Response(
+      JSON.stringify({ error: "Failed to get delete user" }),
+      {
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+        status: 500,
+      },
+    );
+  }
+
+  return new Response(
+    JSON.stringify({
+      "id": (profile[0] as IProfile).id,
+      "tier": (profile[0] as IProfile).tier,
+      "subscriptionProvider": (profile[0] as IProfile).subscriptionProvider,
+      "accountGithub": (profile[0] as IProfile).accountGithub?.token
+        ? true
+        : false,
+      "createdAt": (profile[0] as IProfile).createdAt,
+      "updatedAt": (profile[0] as IProfile).updatedAt,
+    }),
+    {
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+      status: 200,
+    },
+  );
+};
+
+/**
+ * The `profile-v2` function is the entry point for all requests which are related to the users profile. This means that
+ * the function can be used to get the users profile and to handle the users connected accounts.
+ */
+serve(async (req) => {
+  const { url, method } = req;
+
+  /**
+   * We need to handle the preflight request for CORS as it is described in the Supabase documentation:
+   * https://supabase.com/docs/guides/functions/cors
+   */
+  if (method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+
+  try {
+    /**
+     * Create a new Supabase client with the anonymous key and the authorization header from the request. This allows
+     * us to access the database as the user that is currently signed in.
+     */
+    const userSupabaseClient = createClient(
+      FEEDDECK_SUPABASE_URL,
+      FEEDDECK_SUPABASE_ANON_KEY,
+      {
+        global: {
+          headers: { Authorization: req.headers.get("Authorization")! },
+        },
+        auth: {
+          autoRefreshToken: false,
+          persistSession: false,
+        },
+      },
+    );
+
+    /**
+     * Get the user from the request. If there is no user, we return an error.
+     */
+    const { data: { user } } = await userSupabaseClient.auth.getUser();
+    if (!user) {
+      return new Response(JSON.stringify({ error: "Unauthorized" }), {
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+        status: 401,
+      });
+    }
+
+    /**
+     * Create a new admin client for Supabase, which is used in the following steps to access the database. This client
+     * is required because the user client does not have the permissions to get a users profile.
+     */
+    const adminSupabaseClient = createClient(
+      FEEDDECK_SUPABASE_URL,
+      FEEDDECK_SUPABASE_SERVICE_ROLE_KEY,
+      {
+        auth: {
+          autoRefreshToken: false,
+          persistSession: false,
+        },
+      },
+    );
+
+    /**
+     * We use the `URLPattern` library to match the request url to the different endpoints of the function. This allows
+     * us to use a single function for multiple endpoints. If the request method is `POST` we also parse the request
+     * body.
+     */
+    const urlPattern = new URLPattern({ pathname: "/profile-v2/:id" });
+    const matchingPath = urlPattern.exec(url);
+    const id = matchingPath ? matchingPath.pathname.groups.id : null;
+
+    let data = null;
+    if (method === "POST") {
+      data = await req.json();
+    }
+
+    log("debug", "Request data", {
+      user: user,
+      method: method,
+      id: id,
+      data: data ? true : false,
+    });
+
+    /**
+     * Now we can check the request method and the request id to determine which action we need to execute.
+     */
+    switch (true) {
+      case method === "GET" && id === "getProfile":
+        return await getProfile(adminSupabaseClient, user);
+      case method === "POST" && id === "githubAddAccount":
+        return await githubAddAccount(adminSupabaseClient, user, data);
+      case method === "DELETE" && id === "githubDeleteAccount":
+        return await githubDeleteAccount(adminSupabaseClient, user);
+      default:
+        /**
+         * If the request doesn't match any of the above conditions, because it doesn't match the request method and id
+         * we return a `400 Bad Request` error.
+         */
+        return new Response(JSON.stringify({ error: "Bad Request" }), {
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+          status: 400,
+        });
+    }
+  } catch (err) {
+    log("error", "An unexpected error occured", { "error": err.toString() });
+    return new Response(
+      JSON.stringify({ error: "An unexpected error occured" }),
+      {
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+        status: 400,
+      },
+    );
+  }
+});


### PR DESCRIPTION
This commit introduces a new "profile-v2" edge function and deprecates the "profile-v1" edge function. We decided to provide a new edge function for all profile related operation to improve the handling of the different operation the edge function is responsible for.

The main differences to the "profile-v1" functions are:
- Pass the operation id within the request url instead of the body of the request.
- Move the operations for accounts (e.g. GitHub) to seperate files, to improve the readability of the function.
- Do not require the "sourceType" anymore, instead we are using the operation id and request method to determine the operation which should be executed
- The request body is now only used for the data of the corresponding account and not for any other information like the operation id and source information.

<!--
  Keep PR title verbose enough and add prefix telling about what source it touches e.g "[rss] Add feature xyz" or if the
  the PR is not realated to a source use "[core]", e.g. "[core] Fix xyz".

  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
