### PR TITLE
[podcast] Fix Duration and Play Button

### DIFF
--- a/app/lib/widgets/item/details/utils/item_audio_palyer/item_audio_player_controlbuttons.dart
+++ b/app/lib/widgets/item/details/utils/item_audio_palyer/item_audio_player_controlbuttons.dart
@@ -67,15 +67,8 @@ class ItemAudioPlayerControlButtons extends StatelessWidget {
             final playerState = snapshot.data;
             final processingState = playerState?.processingState;
             final playing = playerState?.playing;
-            if (processingState == ProcessingState.loading ||
-                processingState == ProcessingState.buffering) {
-              return Container(
-                margin: const EdgeInsets.all(Constants.spacingSmall),
-                width: 48.0,
-                height: 48.0,
-                child: const CircularProgressIndicator(),
-              );
-            } else if (playing != true) {
+
+            if (playing != true) {
               return IconButton(
                 icon: const Icon(Icons.play_arrow),
                 iconSize: 64.0,

--- a/app/lib/widgets/item/details/utils/item_audio_palyer/item_audio_player_seekbar.dart
+++ b/app/lib/widgets/item/details/utils/item_audio_palyer/item_audio_player_seekbar.dart
@@ -35,6 +35,16 @@ class _ItemAudioPlayerSeekBarState extends State<ItemAudioPlayerSeekBar> {
   /// audio file.
   Duration get _remaining => widget.duration - widget.position;
 
+  /// [_printDuration] prints the provided [duration] in a human readable format
+  /// `HH:mm:ss`.
+  String _printDuration(Duration duration) {
+    String negativeSign = duration.isNegative ? '-' : '';
+    String twoDigits(int n) => n.toString().padLeft(2, '0');
+    String twoDigitMinutes = twoDigits(duration.inMinutes.remainder(60).abs());
+    String twoDigitSeconds = twoDigits(duration.inSeconds.remainder(60).abs());
+    return '$negativeSign${twoDigits(duration.inHours)}:$twoDigitMinutes:$twoDigitSeconds';
+  }
+
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
@@ -110,10 +120,7 @@ class _ItemAudioPlayerSeekBarState extends State<ItemAudioPlayerSeekBar> {
           left: Constants.spacingMiddle,
           bottom: 0.0,
           child: Text(
-            RegExp(r'((^0*[1-9]\d*:)?\d{2}:\d{2})\.\d+$')
-                    .firstMatch('${widget.position}')
-                    ?.group(1) ??
-                '${widget.position}',
+            _printDuration(widget.position),
             style: Theme.of(context).textTheme.bodySmall,
           ),
         ),
@@ -121,10 +128,7 @@ class _ItemAudioPlayerSeekBarState extends State<ItemAudioPlayerSeekBar> {
           right: Constants.spacingMiddle,
           bottom: 0.0,
           child: Text(
-            RegExp(r'((^0*[1-9]\d*:)?\d{2}:\d{2})\.\d+$')
-                    .firstMatch('$_remaining')
-                    ?.group(1) ??
-                '$_remaining',
+            _printDuration(_remaining),
             style: Theme.of(context).textTheme.bodySmall,
           ),
         ),

--- a/supabase/functions/_shared/feed/podcast.ts
+++ b/supabase/functions/_shared/feed/podcast.ts
@@ -68,13 +68,16 @@ export const getPodcastFeed = async (
   if (feed.links.length > 0) {
     source.link = feed.links[0];
   }
-  if (
-    // deno-lint-ignore no-explicit-any
-    !source.icon && (feed.image?.url || (feed as any)["itunes:image"]?.href)
-  ) {
-    // deno-lint-ignore no-explicit-any
-    source.icon = feed.image?.url || (feed as any)["itunes:image"]?.href;
-    source.icon = await uploadSourceIcon(supabaseClient, source);
+  if (!source.icon) {
+    if (feed.image?.url) {
+      source.icon = feed.image.url;
+      source.icon = await uploadSourceIcon(supabaseClient, source);
+      // deno-lint-ignore no-explicit-any
+    } else if ((feed as any)["itunes:image"]?.href) {
+      // deno-lint-ignore no-explicit-any
+      source.icon = (feed as any)["itunes:image"].href;
+      source.icon = await uploadSourceIcon(supabaseClient, source);
+    }
   }
 
   /**


### PR DESCRIPTION
This commit fixes two bugs within the Podcast player.

It could happen that the play time and remaining time was not shown correctly in the player. This mainly occured in Safari and is now fixed by not using a regular expression to show the time, but instead we have added a new "_printDuration" function which handles the formatting of the durations.

Not only, but mainly on Safari it could also happen, that once a Podcast was started and then paused, the loading spinner was displayed and a user could not continue with the Podcast. This is now fixed, by removing the spinner and only show the play, pause or replay button. As loading indication we are now only using the seek bar.

Last but not least this commit also improves the readability of the code, for parsing the icon of a Podcast feed.

<!--
  Keep PR title verbose enough and add prefix telling about what source it touches e.g "[rss] Add feature xyz" or if the
  the PR is not realated to a source use "[core]", e.g. "[core] Fix xyz".

  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
