### PR TITLE
[core] Fix Border Radius for Drawer

### DIFF
--- a/app/lib/widgets/deck/deck_layout_large.dart
+++ b/app/lib/widgets/deck/deck_layout_large.dart
@@ -195,9 +195,9 @@ class _DeckLayoutLargeState extends State<DeckLayoutLarge> {
       /// The drawer is used to display the [CreateColumn] widget, so that a
       /// user can add a new column without leaving the screen.
       drawer: ClipRRect(
-        borderRadius: const BorderRadius.vertical(
-          top: Radius.circular(Constants.spacingMiddle),
-          bottom: Radius.circular(Constants.spacingMiddle),
+        borderRadius: const BorderRadius.only(
+          topRight: Radius.circular(Constants.spacingMiddle),
+          bottomRight: Radius.circular(Constants.spacingMiddle),
         ),
         child: Drawer(
           width: Constants.columnWidth,


### PR DESCRIPTION
This commit fixes the border radius for the drawer used in the large deck layout. Until now the drawer used the border radius on all edges. This is now fixed to only use the border radius on the right side of the drawer. This is more aligned how the border radius is used in the side sheet for the item details, where we also only use it on the left side.

<!--
  Keep PR title verbose enough and add prefix telling about what source it touches e.g "[rss] Add feature xyz" or if the
  the PR is not realated to a source use "[core]", e.g. "[core] Fix xyz".

  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
