### PR TITLE
[core] Fix Number of Loaded Items per Fetch

### DIFF
--- a/app/lib/repositories/items_repository.dart
+++ b/app/lib/repositories/items_repository.dart
@@ -168,7 +168,7 @@ class ItemsRepository with ChangeNotifier {
       /// filter to page through all the items.
       final data = await filter
           .order('publishedAt')
-          .range(_filters.offsetFilter, _filters.offsetFilter + 50);
+          .range(_filters.offsetFilter, _filters.offsetFilter + 50 - 1);
 
       /// The returned items are added to the [_items] field and the status is
       /// set to [ItemsStatus.loaded] or [ItemsStatus.loadedLast] based on the

--- a/app/lib/widgets/column/header/column_layout_header.dart
+++ b/app/lib/widgets/column/header/column_layout_header.dart
@@ -121,7 +121,7 @@ class _ColumnLayoutHeaderState extends State<ColumnLayoutHeader> {
               ),
               Text(
                 Characters(
-                  '${items.column.sources.length} ${items.column.sources.length == 1 ? 'Source' : 'Sources'} / ${items.items.length} ${items.items.length == 1 ? 'Item' : 'Items'}',
+                  '${items.column.sources.length} ${items.column.sources.length == 1 ? 'Source' : 'Sources'} / ${items.items.length}${items.status == ItemsStatus.loaded ? '+' : ''} ${items.items.length == 1 ? 'Item' : 'Items'}',
                 )
                     .replaceAll(
                       Characters(''),


### PR DESCRIPTION
We always loaded 51 items per fetch instead of 50 items, because we used a range of 0 to 50 which includes the item at position 0 and at position
50. This is now fixed by adjusting the range to 0 to 49, so that exactly 50 items are loaded per fetch request.

This commit also improves the number of loaded items shown in the column header. If the status of the ItemsRepository is "loaded" we add a small "+" symbol behind the number to indicat that there are more items, which could be loaded. If the last page was already fetched (status == "loadedLast") then the "+" symbol isn't shown.

<!--
  Keep PR title verbose enough and add prefix telling about what source it touches e.g "[rss] Add feature xyz" or if the
  the PR is not realated to a source use "[core]", e.g. "[core] Fix xyz".

  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
