### PR TITLE
[core] Clear Cached Items

### DIFF
--- a/app/lib/repositories/items_repository.dart
+++ b/app/lib/repositories/items_repository.dart
@@ -369,7 +369,7 @@ class ItemsRepositoryStore {
   static final ItemsRepositoryStore _instance =
       ItemsRepositoryStore._internal();
 
-  final Map<String, ItemsRepositoryStoreState> itemsRepositoryStoreStates = {};
+  final Map<String, ItemsRepositoryStoreState> _itemsRepositoryStoreStates = {};
 
   factory ItemsRepositoryStore() {
     return _instance;
@@ -382,7 +382,7 @@ class ItemsRepositoryStore {
   /// returns `null` to indicate that we have to get the items from the
   /// database.
   ItemsRepositoryStoreState? get(String columnId) {
-    return itemsRepositoryStoreStates[columnId];
+    return _itemsRepositoryStoreStates[columnId];
   }
 
   /// [set] saves the [items] and [filters] for a [columnId] in the store. This
@@ -397,10 +397,17 @@ class ItemsRepositoryStore {
     ItemsFilters filters,
     List<FDItem> items,
   ) {
-    return itemsRepositoryStoreStates[columnId] = ItemsRepositoryStoreState(
+    return _itemsRepositoryStoreStates[columnId] = ItemsRepositoryStoreState(
       status: status,
       filters: filters,
       items: items,
     );
+  }
+
+  /// [clear] deletes all the stored [_itemsRepositoryStoreStates] from the
+  /// store. This method can be used to clear the cache, e.g. when a user
+  /// changes the active deck or signes out.
+  clear() {
+    _itemsRepositoryStoreStates.clear();
   }
 }

--- a/app/lib/widgets/settings/decks/settings_decks_select.dart
+++ b/app/lib/widgets/settings/decks/settings_decks_select.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import 'package:feeddeck/repositories/app_repository.dart';
+import 'package:feeddeck/repositories/items_repository.dart';
 import 'package:feeddeck/utils/constants.dart';
 
 /// The [SettingsDecksSelect] widget shows a list of the users decks, when the
@@ -19,8 +20,13 @@ class _SettingsDecksSelectState extends State<SettingsDecksSelect> {
   /// [_selectDeck] sets the provided [deckId] as the active deck. The active
   /// deck is updated via the [selectDeck] method of the [AppRepository]. When
   /// the active deck is updated the user is redirected to the decks view.
+  ///
+  /// Before the active deck is changed the [ItemsRepositoryStore] is cleared,
+  /// to trigger a reload of the items once the deck is loaded.
   Future<void> _selectDeck(String deckId) async {
     try {
+      ItemsRepositoryStore().clear();
+
       await Provider.of<AppRepository>(context, listen: false)
           .selectDeck(deckId);
       if (!mounted) return;

--- a/app/lib/widgets/settings/profile/settings_profile_signout.dart
+++ b/app/lib/widgets/settings/profile/settings_profile_signout.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import 'package:supabase_flutter/supabase_flutter.dart' as supabase;
 
+import 'package:feeddeck/repositories/items_repository.dart';
 import 'package:feeddeck/utils/constants.dart';
 import 'package:feeddeck/widgets/general/elevated_button_progress_indicator.dart';
 import 'package:feeddeck/widgets/signin/signin.dart';
@@ -20,12 +21,16 @@ class _SettingsProfileSignOutState extends State<SettingsProfileSignOut> {
 
   /// [_signOut] signs out the currently authenticated user and redirects him
   /// to the [SignIn] screen. This will sign out the user from all devices.
+  ///
+  /// Before the user is signed out the [ItemsRepositoryStore] is cleared, to
+  /// trigger a reload of the items once the user is signed in again.
   Future<void> _signOut() async {
     setState(() {
       _isLoading = true;
     });
 
     try {
+      ItemsRepositoryStore().clear();
       await supabase.Supabase.instance.client.auth.signOut();
 
       setState(() {


### PR DESCRIPTION
The cached items in the "ItemsRepositoryStore" are now cleared when a user selects an active deck in the settings and when a user signes out of the app.

This is done to force a reload of the items in a column, when a user switches between decks. For me this works better because, when I switch between decks I manually trigger a reload for all columns, which is now not necessary anymore.

<!--
  Keep PR title verbose enough and add prefix telling about what source it touches e.g "[rss] Add feature xyz" or if the
  the PR is not realated to a source use "[core]", e.g. "[core] Fix xyz".

  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
