### PR TITLE
[rss] Improve Rendering of Items

### DIFF
--- a/app/lib/widgets/item/details/item_details_rss.dart
+++ b/app/lib/widgets/item/details/item_details_rss.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import 'package:html/parser.dart' show parse;
+
 import 'package:feeddeck/models/item.dart';
 import 'package:feeddeck/models/source.dart';
 import 'package:feeddeck/widgets/item/details/utils/item_description.dart';
@@ -17,8 +19,26 @@ class ItemDetailsRSS extends StatelessWidget {
   final FDItem item;
   final FDSource source;
 
+  /// [_buildImage] renders the [item.media] when the [shouldBeRendered] is
+  /// `true`. If it is `false` an empty container is returned.
+  Widget _buildImage(bool shouldBeRendered) {
+    if (!shouldBeRendered) {
+      return Container();
+    }
+
+    return ItemMedia(
+      itemMedia: item.media,
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
+    /// Check if the description of the RSS feed contains an image. If this is
+    /// the case we do not render the image from the [item.media] because the
+    /// image is already rendered in the [ItemDescription] widget.
+    final descriptionContainImage =
+        parse(item.description).querySelectorAll('img').isNotEmpty;
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       mainAxisAlignment: MainAxisAlignment.start,
@@ -30,13 +50,11 @@ class ItemDetailsRSS extends StatelessWidget {
           item: item,
           source: source,
         ),
-        ItemMedia(
-          itemMedia: item.media,
-        ),
+        _buildImage(!descriptionContainImage),
         ItemDescription(
           itemDescription: item.description,
-          sourceFormat: DescriptionFormat.plain,
-          tagetFormat: DescriptionFormat.plain,
+          sourceFormat: DescriptionFormat.html,
+          tagetFormat: DescriptionFormat.markdown,
         ),
       ],
     );

--- a/app/lib/widgets/item/details/utils/item_description.dart
+++ b/app/lib/widgets/item/details/utils/item_description.dart
@@ -47,7 +47,7 @@ class ItemDescription extends StatelessWidget {
   Widget _buildMarkdown(BuildContext context, String content) {
     return MarkdownBody(
       selectable: true,
-      data: content,
+      data: content.trim(),
       styleSheet: MarkdownStyleSheet(
         code: TextStyle(
           fontFamily: getMonospaceFontFamily(),
@@ -135,7 +135,7 @@ class ItemDescription extends StatelessWidget {
   /// [_buildPlain] renders the provided [content] as plain text.
   Widget _buildPlain(String content) {
     return SelectableText(
-      content,
+      content.trim(),
       textAlign: TextAlign.left,
       style: const TextStyle(
         fontWeight: FontWeight.normal,

--- a/app/lib/widgets/item/details/utils/item_subtitle.dart
+++ b/app/lib/widgets/item/details/utils/item_subtitle.dart
@@ -23,9 +23,10 @@ class ItemSubtitle extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final sourceType = source.type.toLocalizedString();
-    final sourceTitle = source.title != '' ? ' / ${source.title}' : '';
-    final author =
-        item.author != null && item.author != '' ? ' / ${item.author}' : '';
+    final sourceTitle = source.title != '' ? ' / ${source.title.trim()}' : '';
+    final author = item.author != null && item.author != ''
+        ? ' / ${item.author!.trim()}'
+        : '';
     final publishedAt =
         ' / ${DateFormat.yMMMMd().add_Hm().format(DateTime.fromMillisecondsSinceEpoch(item.publishedAt * 1000))}';
 

--- a/app/lib/widgets/item/preview/item_preview_rss.dart
+++ b/app/lib/widgets/item/preview/item_preview_rss.dart
@@ -41,7 +41,7 @@ class ItemPreviewRSS extends StatelessWidget {
         ),
         ItemDescription(
           itemDescription: item.description,
-          sourceFormat: DescriptionFormat.plain,
+          sourceFormat: DescriptionFormat.html,
           tagetFormat: DescriptionFormat.plain,
         ),
       ],

--- a/app/lib/widgets/item/preview/utils/item_description.dart
+++ b/app/lib/widgets/item/preview/utils/item_description.dart
@@ -46,7 +46,7 @@ class ItemDescription extends StatelessWidget {
       ),
       child: MarkdownBody(
         selectable: false,
-        data: content,
+        data: content.trim(),
         styleSheet: MarkdownStyleSheet(
           code: TextStyle(
             fontFamily: getMonospaceFontFamily(),
@@ -87,7 +87,7 @@ class ItemDescription extends StatelessWidget {
         bottom: Constants.spacingExtraSmall,
       ),
       child: Text(
-        content,
+        content.trim(),
         maxLines: 5,
         style: const TextStyle(
           overflow: TextOverflow.ellipsis,

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -321,7 +321,7 @@ packages:
     source: hosted
     version: "1.1.0"
   html:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: html
       sha256: "3a7812d5bcd2894edf53dfaf8cd640876cf6cef50a8f238745c8b8120ea74d3a"

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -43,6 +43,7 @@ dependencies:
   collection: ^1.17.0
   flutter_markdown: ^0.6.14
   flutter_native_splash: ^2.2.19
+  html: ^0.15.4
   html2md: ^1.2.6
   intl: ^0.18.1
   just_audio: ^0.9.32

--- a/supabase/functions/_shared/feed/rss.ts
+++ b/supabase/functions/_shared/feed/rss.ts
@@ -232,7 +232,7 @@ const getMedia = (entry: FeedEntry): string | undefined => {
     for (const media of entry["media:content"]) {
       if (
         media.medium && media.medium === "image" && media.url &&
-        media.url.startsWith("https://")
+        media.url.startsWith("https://") && !media.url.endsWith(".svg")
       ) {
         return media.url;
       }
@@ -253,7 +253,8 @@ const getMedia = (entry: FeedEntry): string | undefined => {
           if (
             mediaContent.medium && mediaContent.medium === "image" &&
             mediaContent.url &&
-            mediaContent.url.startsWith("https://")
+            mediaContent.url.startsWith("https://") &&
+            !mediaContent.url.endsWith(".svg")
           ) {
             return mediaContent.url;
           }
@@ -267,7 +268,8 @@ const getMedia = (entry: FeedEntry): string | undefined => {
       if (
         attachment.mimeType && attachment.mimeType.startsWith("image/") &&
         attachment.url &&
-        attachment.url.startsWith("https://")
+        attachment.url.startsWith("https://") &&
+        !attachment.url.endsWith(".svg")
       ) {
         return attachment.url;
       }
@@ -278,7 +280,10 @@ const getMedia = (entry: FeedEntry): string | undefined => {
     const matches = /<img[^>]+\bsrc=["']([^"']+)["']/.exec(
       entry.description?.value,
     );
-    if (matches && matches.length == 2 && matches[1].startsWith("https://")) {
+    if (
+      matches && matches.length == 2 && matches[1].startsWith("https://") &&
+      !matches[1].endsWith(".svg")
+    ) {
       return matches[1];
     }
   }
@@ -287,7 +292,10 @@ const getMedia = (entry: FeedEntry): string | undefined => {
     const matches = /<img[^>]+\bsrc=["']([^"']+)["']/.exec(
       entry.content?.value,
     );
-    if (matches && matches.length == 2 && matches[1].startsWith("https://")) {
+    if (
+      matches && matches.length == 2 && matches[1].startsWith("https://") &&
+      !matches[1].endsWith(".svg")
+    ) {
       return matches[1];
     }
   }


### PR DESCRIPTION
The items of an RSS feed are now rendered better, to achieve this we did the following changes:

- Remove leading and trailing whitespaces from the item description which should be rendered.
- Check if the media file of an item is an SVG image. If this is the case we will not add it to the "media" field in the database, because currently the CachedNetworkImage widget can not render SVGs. If we want to render them, we run into serious performance issue so we skip them completly.
- Always assume that the content of an RSS feed contains HTML and render them as plain text in the preview and as markdown in the details. Since we also render images from the description now, we check if the "item.media" image should be rendered. If the description contains an image we do not render our own image. If the description doesn't contain a image we render it.

<!--
  Keep PR title verbose enough and add prefix telling about what source it touches e.g "[rss] Add feature xyz" or if the
  the PR is not realated to a source use "[core]", e.g. "[core] Fix xyz".

  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
