### PR TITLE
[core] Improve Tabs Handling in Small Deck Layout

### DIFF
--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -12,6 +12,7 @@ import 'package:provider/provider.dart';
 import 'package:window_manager/window_manager.dart';
 
 import 'package:feeddeck/repositories/app_repository.dart';
+import 'package:feeddeck/repositories/layout_repository.dart';
 import 'package:feeddeck/repositories/profile_repository.dart';
 import 'package:feeddeck/repositories/settings_repository.dart';
 import 'package:feeddeck/utils/constants.dart';
@@ -135,6 +136,7 @@ class FeedDeckApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MultiProvider(
       providers: [
+        ChangeNotifierProvider(create: (_) => LayoutRepository()),
         ChangeNotifierProvider(create: (_) => AppRepository()),
         ChangeNotifierProvider(create: (_) => ProfileRepository()),
       ],

--- a/app/lib/repositories/layout_repository.dart
+++ b/app/lib/repositories/layout_repository.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/foundation.dart';
+
+/// The [LayoutRepository] is used to store several layout information of the
+/// app, which can be modifed or should be modifed within different locations.
+class LayoutRepository with ChangeNotifier {
+  /// [_deckLayoutSmallInitialTabIndex] stores the selected tab index of the
+  /// [DeckLayoutSmall] widget. This is used that we display the same tab when
+  /// a user switches between the small and large layout (e.g. portrait and
+  /// landscape mode on mobile devices) and that we can reset the tab index when
+  /// a user selects a new deck.
+  int deckLayoutSmallInitialTabIndex = 0;
+}

--- a/app/lib/widgets/deck/deck_layout_large.dart
+++ b/app/lib/widgets/deck/deck_layout_large.dart
@@ -5,6 +5,7 @@ import 'package:scroll_to_index/scroll_to_index.dart';
 
 import 'package:feeddeck/models/source.dart';
 import 'package:feeddeck/repositories/app_repository.dart';
+import 'package:feeddeck/repositories/layout_repository.dart';
 import 'package:feeddeck/utils/constants.dart';
 import 'package:feeddeck/widgets/column/column_layout.dart';
 import 'package:feeddeck/widgets/column/create/create_column.dart';
@@ -224,10 +225,20 @@ class _DeckLayoutLargeState extends State<DeckLayoutLarge> {
                       backgroundColor: Constants.background,
                       selectedIndex: null,
 
-                      /// When a user selects a destination in the navigation rail
-                      /// we scroll to the corresponding column by using the
-                      /// `scroll_to_index` package.
+                      /// When a user selects a destination in the navigation
+                      /// rail we scroll to the corresponding column by using
+                      /// the `scroll_to_index` package.
                       onDestinationSelected: (int index) {
+                        /// Before we scroll to the corresponding column, we
+                        /// also update the [deckLayoutSmallInitialTabIndex] in
+                        /// the [LayoutRepository] so that the correct tab is
+                        /// also selected when a user switches to the small
+                        /// layout.
+                        Provider.of<LayoutRepository>(
+                          context,
+                          listen: false,
+                        ).deckLayoutSmallInitialTabIndex = index;
+
                         _scrollController.scrollToIndex(
                           index,
                           preferPosition: AutoScrollPosition.end,
@@ -244,8 +255,8 @@ class _DeckLayoutLargeState extends State<DeckLayoutLarge> {
 
                       /// We add two additional items to the navigation rail via
                       /// the trailing property. These items are used to allow a
-                      /// user to create a new column and to go to the settings of
-                      /// the app.
+                      /// user to create a new column and to go to the settings
+                      /// of the app.
                       trailing: Expanded(
                         child: Align(
                           alignment: Alignment.bottomCenter,

--- a/app/lib/widgets/settings/decks/settings_decks_select.dart
+++ b/app/lib/widgets/settings/decks/settings_decks_select.dart
@@ -4,6 +4,7 @@ import 'package:provider/provider.dart';
 
 import 'package:feeddeck/repositories/app_repository.dart';
 import 'package:feeddeck/repositories/items_repository.dart';
+import 'package:feeddeck/repositories/layout_repository.dart';
 import 'package:feeddeck/utils/constants.dart';
 
 /// The [SettingsDecksSelect] widget shows a list of the users decks, when the
@@ -20,12 +21,17 @@ class _SettingsDecksSelectState extends State<SettingsDecksSelect> {
   /// [_selectDeck] sets the provided [deckId] as the active deck. The active
   /// deck is updated via the [selectDeck] method of the [AppRepository]. When
   /// the active deck is updated the user is redirected to the decks view.
-  ///
-  /// Before the active deck is changed the [ItemsRepositoryStore] is cleared,
-  /// to trigger a reload of the items once the deck is loaded.
   Future<void> _selectDeck(String deckId) async {
     try {
+      /// Before the active deck is changed the [ItemsRepositoryStore] is
+      /// cleared, to trigger a reload of the items once the deck is loaded.
       ItemsRepositoryStore().clear();
+
+      /// We also have to reset the tab index when the user selects a new deck,
+      /// so that the first tab is selected instead of the tab with the same
+      /// index as in the previously selected deck.
+      Provider.of<LayoutRepository>(context, listen: false)
+          .deckLayoutSmallInitialTabIndex = 0;
 
       await Provider.of<AppRepository>(context, listen: false)
           .selectDeck(deckId);


### PR DESCRIPTION
This commit improves the handling of tabs in the samll deck layout. We are now saving the selected tabs index in the newly added "LayoutRepository" so that we can reuse the selected tab when a user switches between the small and large layout. We can now also set the tab which should be initially selected in the large layout when a user selects a column in the navigation rail. Last but not least we can also reset the initial tab index when a user selects a new deck in the settings, so that we always display the first column instead of the column with the same index as it was selected in the previous deck.

<!--
  Keep PR title verbose enough and add prefix telling about what source it touches e.g "[rss] Add feature xyz" or if the
  the PR is not realated to a source use "[core]", e.g. "[core] Fix xyz".

  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
