### PR TITLE
[github] Fix Notification Links for PRs

### DIFF
--- a/supabase/functions/_shared/feed/github.ts
+++ b/supabase/functions/_shared/feed/github.ts
@@ -110,12 +110,7 @@ export const getGithubFeed = async (
         columnId: source.columnId,
         sourceId: source.id,
         title: notification.subject?.title ?? "Notification",
-        link: notification.subject?.url
-          ? `https://github.com/${notification.subject?.url.replace(
-            "https://api.github.com/repos/",
-            "",
-          )}`
-          : "",
+        link: getLinkFromApiUrl(notification.subject?.url),
         media: notification.repository.owner.avatar_url,
         description: formatDescription(notification),
         author: notification.repository?.full_name,
@@ -397,6 +392,25 @@ const request = async (
   }
 
   return await res.json();
+};
+
+/**
+ * `getLinkFromApiUrl` returns a link which can be clicked by a user based on the given GitHub API url. If there is no
+ * url given we return the default GitHub notifications link.
+ */
+const getLinkFromApiUrl = (url?: string): string => {
+  if (!url) {
+    return "https://github.com/notifications";
+  }
+
+  if (/^https:\/\/api.github.com\/repos\/.*\/.*\/pulls\/\d+$/.test(url)) {
+    const n = url.lastIndexOf("pulls");
+    url = url.slice(0, n) + url.slice(n).replace("pulls", "pull");
+  }
+
+  return `https://github.com/${
+    url.replace("https://api.github.com/repos/", "")
+  }`;
 };
 
 /**

--- a/supabase/functions/_shared/feed/x.ts
+++ b/supabase/functions/_shared/feed/x.ts
@@ -41,7 +41,6 @@ export const getXFeed = async (
     throw new Error("Invalid feed");
   }
   const feed = JSON.parse(matches[1]) as Feed;
-  console.log(feed);
 
   /**
    * Generate a source id based on the user id, column id and the normalized `twitter` options. Besides that we also set


### PR DESCRIPTION
If a notification was related to a pull request the link we added to the item didn't work. This should now be fixed, so that when a user clicks on the item he is redirected to the correct pull request which is associated with the item.

This commit also removes an unnecessary "console.log" statement.

<!--
  Keep PR title verbose enough and add prefix telling about what source it touches e.g "[rss] Add feature xyz" or if the
  the PR is not realated to a source use "[core]", e.g. "[core] Fix xyz".

  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
