### PR TITLE
[youtube] Add Desktop Support

### DIFF
--- a/app/lib/widgets/item/details/item_details_youtube.dart
+++ b/app/lib/widgets/item/details/item_details_youtube.dart
@@ -1,17 +1,11 @@
-import 'dart:io';
-
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-
-import 'package:youtube_player_iframe/youtube_player_iframe.dart';
 
 import 'package:feeddeck/models/item.dart';
 import 'package:feeddeck/models/source.dart';
-import 'package:feeddeck/utils/constants.dart';
 import 'package:feeddeck/widgets/item/details/utils/item_description.dart';
-import 'package:feeddeck/widgets/item/details/utils/item_media.dart';
 import 'package:feeddeck/widgets/item/details/utils/item_subtitle.dart';
 import 'package:feeddeck/widgets/item/details/utils/item_title.dart';
+import 'package:feeddeck/widgets/item/details/utils/item_youtube/item_youtube_video.dart';
 
 class ItemDetailsYoutube extends StatelessWidget {
   const ItemDetailsYoutube({
@@ -22,22 +16,6 @@ class ItemDetailsYoutube extends StatelessWidget {
 
   final FDItem item;
   final FDSource source;
-
-  /// [_buildMedia] returns the media element for the item. On the web we are
-  /// using the [YoutubeVideo] widget to render the video, so that a user can
-  /// directly play the YouTube video. On all other platforms we display the
-  /// thumbnail of the video.
-  Widget _buildMedia() {
-    if (kIsWeb || Platform.isAndroid || Platform.isIOS) {
-      return YoutubeVideo(
-        videoUrl: item.link,
-      );
-    }
-
-    return ItemMedia(
-      itemMedia: item.media,
-    );
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -52,61 +30,16 @@ class ItemDetailsYoutube extends StatelessWidget {
           item: item,
           source: source,
         ),
-        _buildMedia(),
+        ItemYoutubeVideo(
+          item.media,
+          item.link,
+        ),
         ItemDescription(
           itemDescription: item.description,
           sourceFormat: DescriptionFormat.plain,
           tagetFormat: DescriptionFormat.plain,
         ),
       ],
-    );
-  }
-}
-
-class YoutubeVideo extends StatefulWidget {
-  const YoutubeVideo({
-    super.key,
-    required this.videoUrl,
-  });
-
-  final String videoUrl;
-
-  @override
-  State<YoutubeVideo> createState() => _YoutubeVideoState();
-}
-
-class _YoutubeVideoState extends State<YoutubeVideo> {
-  late YoutubePlayerController _controller;
-
-  @override
-  void initState() {
-    super.initState();
-    _controller = YoutubePlayerController(
-      params: const YoutubePlayerParams(
-        showControls: true,
-        showFullscreenButton: false,
-      ),
-    );
-
-    _controller.cueVideoByUrl(mediaContentUrl: widget.videoUrl);
-    _controller.cueVideoById(
-      videoId: widget.videoUrl.replaceFirst(
-        'https://www.youtube.com/watch?v=',
-        '',
-      ),
-    );
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.only(
-        bottom: Constants.spacingMiddle,
-      ),
-      child: YoutubePlayer(
-        controller: _controller,
-        aspectRatio: 16 / 9,
-      ),
     );
   }
 }

--- a/app/lib/widgets/item/details/utils/item_videos.dart
+++ b/app/lib/widgets/item/details/utils/item_videos.dart
@@ -1,3 +1,6 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import 'package:media_kit/media_kit.dart';
@@ -42,16 +45,34 @@ class ItemVideos extends StatelessWidget {
   }
 }
 
+/// The [ItemVideoQuality] class is used to store the different qualities of a
+/// video. It is used in combination with the [ItemVideoPlayer] widget.
+class ItemVideoQuality {
+  const ItemVideoQuality({
+    required this.quality,
+    required this.video,
+  });
+
+  final String quality;
+  final String video;
+}
+
 /// The [ItemVideoPlayer] widget is used to display a video, which can be played
 /// by the user. It should be used in combination with the [ItemVideos] widget
 /// and is responsible for the actual implementation of the video player.
+///
+/// The optional [qualities] parameter can be used to display a list of
+/// different qualities for the video, so that a user can select a lower quality
+/// if the video is not loading fast enough.
 class ItemVideoPlayer extends StatefulWidget {
   const ItemVideoPlayer({
     super.key,
     required this.video,
+    this.qualities,
   });
 
   final String video;
+  final List<ItemVideoQuality>? qualities;
 
   @override
   State<ItemVideoPlayer> createState() => _ItemVideoPlayerState();
@@ -60,6 +81,113 @@ class ItemVideoPlayer extends StatefulWidget {
 class _ItemVideoPlayerState extends State<ItemVideoPlayer> {
   late final player = Player();
   late final controller = VideoController(player);
+
+  /// [_buildQualityButton] returns a button which can be used to display a list
+  /// of different qualities for the video, so that a user can select a lower
+  /// quality if the video is not loading fast enough.
+  Widget _buildQualityButton() {
+    return IconButton(
+      onPressed: () {
+        showModalBottomSheet(
+          context: context,
+          isScrollControlled: true,
+          isDismissible: true,
+          useSafeArea: true,
+          elevation: 0,
+          backgroundColor: Colors.transparent,
+          constraints: const BoxConstraints(
+            maxWidth: Constants.centeredFormMaxWidth,
+          ),
+          builder: (BuildContext context) {
+            return Container(
+              margin: const EdgeInsets.all(
+                Constants.spacingMiddle,
+              ),
+              padding: const EdgeInsets.only(
+                left: Constants.spacingMiddle,
+                right: Constants.spacingMiddle,
+              ),
+              decoration: const BoxDecoration(
+                color: Constants.background,
+                borderRadius: BorderRadius.all(
+                  Radius.circular(Constants.spacingMiddle),
+                ),
+              ),
+              child: Wrap(
+                alignment: WrapAlignment.center,
+                crossAxisAlignment: WrapCrossAlignment.center,
+                children: widget.qualities!
+                    .map(
+                      (e) => ListTile(
+                        mouseCursor: SystemMouseCursors.click,
+                        onTap: () {
+                          Navigator.of(context).pop();
+                          player.open(
+                            Media(e.video),
+                            play: true,
+                          );
+                        },
+                        title: Text(e.quality),
+                      ),
+                    )
+                    .toList(),
+              ),
+            );
+          },
+        );
+      },
+      icon: const Icon(Icons.tune),
+    );
+  }
+
+  /// [_buildBottomButtonBar] returns the list of buttons which are displayed in
+  /// the bottom button bar of the video player. If the [qualities] parameter is
+  /// not null, a button to select the quality of the video is added to the
+  /// bottom button bar. If the [isMobile] parameter is true, the bottom button
+  /// bar contains the default buttons from the [MaterialVideoControlsThemeData]
+  /// theme, if it is false it contains the default buttons from the
+  /// [MaterialDesktopVideoControlsThemeData] theme.
+  List<Widget> _buildBottomButtonBar(bool isMobile) {
+    if (isMobile) {
+      if (widget.qualities != null) {
+        return [
+          const MaterialPositionIndicator(),
+          const Spacer(),
+          _buildQualityButton(),
+          const MaterialFullscreenButton(),
+        ];
+      }
+
+      return const [
+        MaterialPositionIndicator(),
+        Spacer(),
+        MaterialFullscreenButton(),
+      ];
+    }
+
+    if (widget.qualities != null) {
+      return [
+        const MaterialDesktopSkipPreviousButton(),
+        const MaterialDesktopPlayOrPauseButton(),
+        const MaterialDesktopSkipNextButton(),
+        const MaterialDesktopVolumeButton(),
+        const MaterialDesktopPositionIndicator(),
+        const Spacer(),
+        _buildQualityButton(),
+        const MaterialDesktopFullscreenButton(),
+      ];
+    }
+
+    return const [
+      MaterialDesktopSkipPreviousButton(),
+      MaterialDesktopPlayOrPauseButton(),
+      MaterialDesktopSkipNextButton(),
+      MaterialDesktopVolumeButton(),
+      MaterialDesktopPositionIndicator(),
+      Spacer(),
+      MaterialDesktopFullscreenButton(),
+    ];
+  }
 
   @override
   void initState() {
@@ -84,7 +212,37 @@ class _ItemVideoPlayerState extends State<ItemVideoPlayer> {
           child: SizedBox(
             width: constraints.maxWidth,
             height: constraints.maxWidth * 9.0 / 16.0,
-            child: Video(controller: controller),
+            child: MaterialDesktopVideoControlsTheme(
+              normal: MaterialDesktopVideoControlsThemeData(
+                bottomButtonBar: _buildBottomButtonBar(false),
+                seekBarPositionColor: Constants.primary,
+                seekBarThumbColor: Constants.primary,
+              ),
+              fullscreen: const MaterialDesktopVideoControlsThemeData(
+                seekBarPositionColor: Constants.primary,
+                seekBarThumbColor: Constants.primary,
+              ),
+              child: MaterialVideoControlsTheme(
+                normal: MaterialVideoControlsThemeData(
+                  bottomButtonBar: _buildBottomButtonBar(true),
+                  seekBarPositionColor: Constants.primary,
+                  seekBarThumbColor: Constants.primary,
+                ),
+                fullscreen: const MaterialVideoControlsThemeData(
+                  seekBarPositionColor: Constants.primary,
+                  seekBarThumbColor: Constants.primary,
+                ),
+                child: Video(
+                  controller: controller,
+                  controls: kIsWeb ||
+                          Platform.isLinux ||
+                          Platform.isMacOS ||
+                          Platform.isWindows
+                      ? MaterialDesktopVideoControls
+                      : MaterialVideoControls,
+                ),
+              ),
+            ),
           ),
         );
       },

--- a/app/lib/widgets/item/details/utils/item_youtube/item_youtube_video.dart
+++ b/app/lib/widgets/item/details/utils/item_youtube/item_youtube_video.dart
@@ -1,0 +1,27 @@
+library item_youtube_video;
+
+import 'package:flutter/material.dart';
+
+import 'item_youtube_video_stub.dart'
+    if (dart.library.io) 'item_youtube_video_native.dart'
+    if (dart.library.html) 'item_youtube_video_web.dart';
+
+/// The [ItemYoutubeVideo] class implements a widget that displays a video from
+/// YouTube.
+///
+/// This is required because we are using different implementations for the web
+/// and for all other target platforms (Android, iOS, macOS, Windows, Linux). On
+/// the web we display the YouTube video via an `iframe` element. On all other
+/// platforms we are using the [youtube_explode_dart] package to fetch the url
+/// of the YouTube video, which can then be displayed via our [ItemVideoPlayer]
+/// widget.
+///
+/// We decided for this implementation, because on the web we would have to
+/// proxy the calls from the [youtube_explode_dart] because of CORS errors.
+/// Further with the former implementation via the [youtube_player_iframe]
+/// package we were not able to display the video on macOS, Windows and Linux
+/// and we were not able to display the video in fullscreen.
+abstract class ItemYoutubeVideo implements StatefulWidget {
+  factory ItemYoutubeVideo(String? imageUrl, String videoUrl) =>
+      getItemYoutubeVideo(imageUrl, videoUrl);
+}

--- a/app/lib/widgets/item/details/utils/item_youtube/item_youtube_video_native.dart
+++ b/app/lib/widgets/item/details/utils/item_youtube/item_youtube_video_native.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/material.dart';
+
+import 'package:youtube_explode_dart/youtube_explode_dart.dart';
+
+import 'package:feeddeck/utils/constants.dart';
+import 'package:feeddeck/widgets/item/details/utils/item_media.dart';
+import 'package:feeddeck/widgets/item/details/utils/item_videos.dart';
+import 'item_youtube_video.dart';
+
+class ItemYoutubeVideoNative extends StatefulWidget
+    implements ItemYoutubeVideo {
+  const ItemYoutubeVideoNative({
+    super.key,
+    required this.imageUrl,
+    required this.videoUrl,
+  });
+
+  final String? imageUrl;
+  final String videoUrl;
+
+  @override
+  State<ItemYoutubeVideoNative> createState() => _ItemYoutubeVideoNativeState();
+}
+
+class _ItemYoutubeVideoNativeState extends State<ItemYoutubeVideoNative> {
+  final yt = YoutubeExplode();
+  late Future<List<ItemVideoQuality>> _futureFetchVideoUrls;
+
+  Future<List<ItemVideoQuality>> _fetchVideoUrls() async {
+    final streamManifest = await yt.videos.streamsClient.getManifest(
+      widget.videoUrl,
+    );
+    return streamManifest.muxed
+        .sortByVideoQuality()
+        .map(
+          (element) => ItemVideoQuality(
+            quality: element.qualityLabel,
+            video: element.url.toString(),
+          ),
+        )
+        .toList();
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    setState(() {
+      _futureFetchVideoUrls = _fetchVideoUrls();
+    });
+  }
+
+  @override
+  void dispose() {
+    yt.close();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder(
+      future: _futureFetchVideoUrls,
+      builder: (
+        BuildContext context,
+        AsyncSnapshot<List<ItemVideoQuality>> snapshot,
+      ) {
+        if (snapshot.connectionState == ConnectionState.none ||
+            snapshot.connectionState == ConnectionState.waiting ||
+            snapshot.hasError ||
+            snapshot.data == null) {
+          return ItemMedia(itemMedia: widget.imageUrl);
+        }
+
+        return Container(
+          padding: const EdgeInsets.only(
+            bottom: Constants.spacingMiddle,
+          ),
+          child: ItemVideoPlayer(
+            video: snapshot.data!.first.video,
+            qualities: snapshot.data,
+          ),
+        );
+      },
+    );
+  }
+}
+
+ItemYoutubeVideo getItemYoutubeVideo(String? imageUrl, String videoUrl) =>
+    ItemYoutubeVideoNative(
+      imageUrl: imageUrl,
+      videoUrl: videoUrl,
+    );

--- a/app/lib/widgets/item/details/utils/item_youtube/item_youtube_video_stub.dart
+++ b/app/lib/widgets/item/details/utils/item_youtube/item_youtube_video_stub.dart
@@ -1,0 +1,6 @@
+import 'item_youtube_video.dart';
+
+ItemYoutubeVideo getItemYoutubeVideo(String? imageUrl, String videoUrl) =>
+    throw UnsupportedError(
+      'Can not ItemYoutubeVideo without the packages dart:html or dart:io',
+    );

--- a/app/lib/widgets/item/details/utils/item_youtube/item_youtube_video_web.dart
+++ b/app/lib/widgets/item/details/utils/item_youtube/item_youtube_video_web.dart
@@ -1,0 +1,73 @@
+import 'dart:html'; // ignore: avoid_web_libraries_in_flutter
+
+import 'dart:ui' as ui;
+
+import 'package:flutter/material.dart';
+
+import 'package:feeddeck/utils/constants.dart';
+import 'item_youtube_video.dart';
+
+class ItemYoutubeVideoWeb extends StatefulWidget implements ItemYoutubeVideo {
+  const ItemYoutubeVideoWeb({
+    super.key,
+    required this.imageUrl,
+    required this.videoUrl,
+  });
+
+  final String? imageUrl;
+  final String videoUrl;
+
+  @override
+  State<ItemYoutubeVideoWeb> createState() => _ItemYoutubeVideoWebState();
+}
+
+class _ItemYoutubeVideoWebState extends State<ItemYoutubeVideoWeb> {
+  final IFrameElement _iframeElement = IFrameElement();
+
+  @override
+  void initState() {
+    super.initState();
+    _iframeElement.src =
+        'https://www.youtube-nocookie.com/embed/${widget.videoUrl.replaceFirst(
+      'https://www.youtube.com/watch?v=',
+      '',
+    )}';
+    _iframeElement.style.border = 'none';
+    _iframeElement.allowFullscreen = true;
+
+    // ignore: undefined_prefixed_name
+    ui.platformViewRegistry.registerViewFactory(
+      widget.videoUrl,
+      (int viewId) => _iframeElement,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.only(
+        bottom: Constants.spacingMiddle,
+      ),
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          return Center(
+            child: SizedBox(
+              width: constraints.maxWidth,
+              height: constraints.maxWidth * 9.0 / 16.0,
+              child: HtmlElementView(
+                key: Key(widget.videoUrl),
+                viewType: widget.videoUrl,
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+ItemYoutubeVideo getItemYoutubeVideo(String? imageUrl, String videoUrl) =>
+    ItemYoutubeVideoWeb(
+      imageUrl: imageUrl,
+      videoUrl: videoUrl,
+    );

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -1270,19 +1270,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
-  youtube_player_iframe:
+  youtube_explode_dart:
     dependency: "direct main"
     description:
-      name: youtube_player_iframe
-      sha256: d7aec9083430db4e5da83a3b5d7b7fcbb93cfa027d9f680ce3c7e7cd20724305
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.0.4"
-  youtube_player_iframe_web:
-    dependency: transitive
-    description:
-      name: youtube_player_iframe_web
-      sha256: c7020816031600349b56d2729d4e8be011fcb723ff7dc2dd0cdf72096a0e5ff4
+      name: youtube_explode_dart
+      sha256: "98fd11b51adbbca76cbdb17f560168f1d7a9835cecceea965f49eb1e5eed155c"
       url: "https://pub.dev"
     source: hosted
     version: "2.0.2"

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -68,7 +68,7 @@ dependencies:
   timeago: ^3.4.0
   url_launcher: ^6.1.10
   window_manager: ^0.3.4
-  youtube_player_iframe: ^4.0.4
+  youtube_explode_dart: ^2.0.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
It is now pissible to play YouTube videos on the native desktop clients. To achieve this we removed the "youtube_player_iframe" package which was used before to play YouTube video, but which only supported web, iOS and Android as target platforms.

On the web we are now using our own implementation to render an iframe with for the YouTube video.

On all other platforms we are now using the "youtube_explode_dart" package to fetch the video urls for a YouTube video and then we display them within our own video player (the "ItemVideoPlayer" widget which was added in https://github.com/feeddeck/feeddeck/pull/51). We also decided to switch the package for the iOS and Android implementation which already worked before, because we are now able to play YouTube videos in fullscreen and we only have to maintain an exception for the web implementation.

The "ItemVideoPlayer" widget now also supports multiple qualities of an video via the "qualities" paramter, which allows a user to switch between the different video qualities which are available for a YouTube video. Last but not least the widget now uses our primary color for the seek bar.

<!--
  Keep PR title verbose enough and add prefix telling about what source it touches e.g "[rss] Add feature xyz" or if the
  the PR is not realated to a source use "[core]", e.g. "[core] Fix xyz".

  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
