### PR TITLE
[core] Fix Modal Bottom Sheet Size for Images

### DIFF
--- a/app/lib/widgets/item/details/utils/item_description.dart
+++ b/app/lib/widgets/item/details/utils/item_description.dart
@@ -87,6 +87,9 @@ class ItemDescription extends StatelessWidget {
                   isDismissible: true,
                   useSafeArea: true,
                   backgroundColor: Colors.black,
+                  constraints: const BoxConstraints(
+                    maxWidth: double.infinity,
+                  ),
                   builder: (BuildContext context) {
                     return Scaffold(
                       backgroundColor: Colors.black,

--- a/app/lib/widgets/item/details/utils/item_media.dart
+++ b/app/lib/widgets/item/details/utils/item_media.dart
@@ -38,6 +38,9 @@ class ItemMedia extends StatelessWidget {
               isDismissible: true,
               useSafeArea: true,
               backgroundColor: Colors.black,
+              constraints: const BoxConstraints(
+                maxWidth: double.infinity,
+              ),
               builder: (BuildContext context) {
                 return Scaffold(
                   backgroundColor: Colors.black,

--- a/app/lib/widgets/item/details/utils/item_media_gallery.dart
+++ b/app/lib/widgets/item/details/utils/item_media_gallery.dart
@@ -34,6 +34,9 @@ class ItemMediaGallery extends StatelessWidget {
             isDismissible: true,
             useSafeArea: true,
             backgroundColor: Colors.black,
+            constraints: const BoxConstraints(
+              maxWidth: double.infinity,
+            ),
             builder: (BuildContext context) {
               return ItemMediaGalleryModal(
                 initialItemMediaIndex: itemMediaIndex,


### PR DESCRIPTION
The size of the modal bottom sheet to display images had always a max width of 640px on large screens. This wasn't intended an the modal bottom sheet should fill the whole screen. This is now fixed, so that when a user clicks on an image in the details view of an item, the whole screen is used to display the image.

<!--
  Keep PR title verbose enough and add prefix telling about what source it touches e.g "[rss] Add feature xyz" or if the
  the PR is not realated to a source use "[core]", e.g. "[core] Fix xyz".

  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
