### PR TITLE
[core] Add Missing Divider to Video Quality Selection

### DIFF
--- a/app/lib/widgets/item/details/utils/item_videos.dart
+++ b/app/lib/widgets/item/details/utils/item_videos.dart
@@ -113,24 +113,29 @@ class _ItemVideoPlayerState extends State<ItemVideoPlayer> {
                   Radius.circular(Constants.spacingMiddle),
                 ),
               ),
-              child: Wrap(
-                alignment: WrapAlignment.center,
-                crossAxisAlignment: WrapCrossAlignment.center,
-                children: widget.qualities!
-                    .map(
-                      (e) => ListTile(
-                        mouseCursor: SystemMouseCursors.click,
-                        onTap: () {
-                          Navigator.of(context).pop();
-                          player.open(
-                            Media(e.video),
-                            play: true,
-                          );
-                        },
-                        title: Text(e.quality),
-                      ),
-                    )
-                    .toList(),
+              child: ListView.separated(
+                shrinkWrap: true,
+                separatorBuilder: (context, index) {
+                  return const Divider(
+                    color: Constants.dividerColor,
+                    height: 1,
+                    thickness: 1,
+                  );
+                },
+                itemCount: widget.qualities!.length,
+                itemBuilder: (context, index) {
+                  return ListTile(
+                    mouseCursor: SystemMouseCursors.click,
+                    onTap: () {
+                      Navigator.of(context).pop();
+                      player.open(
+                        Media(widget.qualities![index].video),
+                        play: true,
+                      );
+                    },
+                    title: Text(widget.qualities![index].quality),
+                  );
+                },
               ),
             );
           },


### PR DESCRIPTION
In the modal bottom sheet where a user can select the video quality the dividers between the different qualities were missing. This commit adds the missing divider, so that the modal bottom sheet looks similar to the other modal bottom sheets we are using (e.g. sign out, account settings).

<!--
  Keep PR title verbose enough and add prefix telling about what source it touches e.g "[rss] Add feature xyz" or if the
  the PR is not realated to a source use "[core]", e.g. "[core] Fix xyz".

  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
