### PR TITLE
[github] Fix Icons in Item Preview

### DIFF
--- a/app/lib/widgets/item/preview/item_preview_github.dart
+++ b/app/lib/widgets/item/preview/item_preview_github.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import 'package:feeddeck/models/item.dart';
 import 'package:feeddeck/models/source.dart';
+import 'package:feeddeck/utils/image_url.dart';
 import 'package:feeddeck/widgets/item/preview/utils/details.dart';
 import 'package:feeddeck/widgets/item/preview/utils/item_actions.dart';
 import 'package:feeddeck/widgets/item/preview/utils/item_description.dart';
@@ -29,6 +30,7 @@ class ItemPreviewGithub extends StatelessWidget {
           sourceSubtitle: '${source.type.toLocalizedString()}: ${source.title}',
           sourceType: source.type,
           sourceIcon: item.media,
+          sourceIconType: FDImageType.item,
           itemPublishedAt: item.publishedAt,
           itemIsRead: item.isRead,
         ),


### PR DESCRIPTION
The icons for GitHub items were not shown, because we did not set the correct "sourceIconType", which was required for the "ItemSource" widget.

<!--
  Keep PR title verbose enough and add prefix telling about what source it touches e.g "[rss] Add feature xyz" or if the
  the PR is not realated to a source use "[core]", e.g. "[core] Fix xyz".

  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
