### PR TITLE
[core] Add Custom Cache Manager

### DIFF
--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -223,7 +223,7 @@ packages:
     source: sdk
     version: "0.0.0"
   flutter_cache_manager:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: flutter_cache_manager
       sha256: "8207f27539deb83732fdda03e259349046a39a4c767269285f449ade355d54ba"

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -41,6 +41,7 @@ dependencies:
   cached_network_image: ^3.2.3
   carousel_slider: ^4.2.1
   collection: ^1.17.0
+  flutter_cache_manager: ^3.3.1
   flutter_markdown: ^0.6.14
   flutter_native_splash: ^2.2.19
   html: ^0.15.4

--- a/app/run.sh
+++ b/app/run.sh
@@ -4,8 +4,8 @@ if [[ "$#" -lt 1 ]]; then
   echo "$(basename "$0") -- program to run the app
 
 where:
-    -e|--environment set the environment on which the app should be run, e.g. -e=local
-    -d|--device set the device on which the app should be run, e.g. -d=chrome"
+    -e|--environment set the environment on which the app should be run, e.g. -e=\"local\"
+    -d|--device set the device on which the app should be run, e.g. -d=\"chrome\""
   exit
 fi
 
@@ -27,9 +27,12 @@ done
 
 if [ -z "${environment}" ] || [ -z "${device}" ]; then
   echo "You have to provide an environment and a device"
-  echo "Example: $0 -e=local -d=chrome"
+  echo "  Example: $0 -e=\"local\" -d=\"chrome\""
+  echo "  Provided: $0 -e=\"${environment}\" -d=\"${device}\""
   exit 1
 fi
+
+echo "Run: $0 -e=\"${environment}\" -d=\"${device}\""
 
 # Load the environment variables from the corresponding ".env" file in the
 # "supabase" directory.
@@ -52,4 +55,4 @@ if [ "${device}" == "chrome" ]; then
 fi
 
 # Run the app on the provided device and environment.
-flutter run -d ${device} ${additional_flags} --dart-define SUPABASE_URL=${supabase_url} --dart-define SUPABASE_ANON_KEY=${FEEDDECK_SUPABASE_ANON_KEY} --dart-define SUPABASE_SITE_URL=${FEEDDECK_SUPABASE_SITE_URL} --dart-define GOOGLE_CLIENT_ID=${FEEDDECK_GOOGLE_CLIENT_ID}
+flutter run -d "${device}" ${additional_flags} --dart-define SUPABASE_URL=${supabase_url} --dart-define SUPABASE_ANON_KEY=${FEEDDECK_SUPABASE_ANON_KEY} --dart-define SUPABASE_SITE_URL=${FEEDDECK_SUPABASE_SITE_URL} --dart-define GOOGLE_CLIENT_ID=${FEEDDECK_GOOGLE_CLIENT_ID}


### PR DESCRIPTION
This commit adds a custom cache manager "CustomCacheManager" which is used in the "CachedNetworkImage" widget. The custom cache manager is required, so that we can adjust the stale periode of cached images. By default the package used 30 days as stale periode, but for our use case 7 days should be enough and we can reduce the storage used by the app.

<!--
  Keep PR title verbose enough and add prefix telling about what source it touches e.g "[rss] Add feature xyz" or if the
  the PR is not realated to a source use "[core]", e.g. "[core] Fix xyz".

  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
