### PR TITLE
[rss] Allow Users to Provide a Website URL

### DIFF
--- a/app/lib/widgets/source/add/add_source_rss.dart
+++ b/app/lib/widgets/source/add/add_source_rss.dart
@@ -14,6 +14,10 @@ import 'package:feeddeck/widgets/source/add/add_source_form.dart';
 const _helpText = '''
 The RSS source can be used to follow all your RSS feeds. You have to provide
 the url for the RSS feed, e.g. `https://www.tagesschau.de/xml/rss2/`.
+
+If you do not know the url of the RSS feed you can also provide the url of the
+website you want to add and we try to find a RSS feed for you, e.g.
+`https://www.tagesschau.de`.
 ''';
 
 /// The [AddSourceRSS] widget is used to display the form to add a new RSS

--- a/supabase/functions/_shared/feed/utils/getFavicon.ts
+++ b/supabase/functions/_shared/feed/utils/getFavicon.ts
@@ -148,8 +148,9 @@ const processURL = (url: string, removeParams: boolean): string => {
 };
 
 /**
- * `processURL` checks if the provided `url` is a relative url. If this is the
- * case the function returns `true`, if the url is absolute it returns `false`.
+ * `isRelativeURL` checks if the provided `url` is a relative url. If this is
+ * the case the function returns `true`, if the url is absolute it returns
+ * `false`.
  */
 const isRelativeURL = (url: string): boolean => {
   return url.startsWith('/') && !url.startsWith('//') &&


### PR DESCRIPTION
Users can now provide the URL of a website instead of the url of a RSS feed via the input field for the RSS source.

This is possible because we are now trying to get and parse the RSS feed for the provided url as usual, but if this operation fails, we try to parse the text as html, so that we can check if it contains a "<link type="application/rss+xml" href="RSS_FEED_URL">" tag. If this is the case we are using this value to try to get and parse the RSS feed again. If it fails again we are returning an error as before.

<!--
  Keep PR title verbose enough and add prefix telling about what source it touches e.g "[rss] Add feature xyz" or if the
  the PR is not realated to a source use "[core]", e.g. "[core] Fix xyz".

  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
