### PR TITLE
[core] Fix `getMedia` Function

### DIFF
--- a/supabase/functions/_shared/feed/medium.ts
+++ b/supabase/functions/_shared/feed/medium.ts
@@ -247,7 +247,7 @@ const getItemDescription = (entry: FeedEntry): string | undefined => {
 const getMedia = (entry: FeedEntry): string | undefined => {
   if (entry.content?.value) {
     const matches = /<img[^>]+\bsrc=["']([^"']+)["']/.exec(
-      entry.content?.value,
+      unescape(entry.content.value),
     );
     if (matches && matches.length == 2 && matches[1].startsWith('https://')) {
       return matches[1];
@@ -256,7 +256,7 @@ const getMedia = (entry: FeedEntry): string | undefined => {
 
   if (entry.description?.value) {
     const matches = /<img[^>]+\bsrc=["']([^"']+)["']/.exec(
-      entry.description?.value,
+      unescape(entry.description.value),
     );
     if (matches && matches.length == 2 && matches[1].startsWith('https://')) {
       return matches[1];

--- a/supabase/functions/_shared/feed/nitter.ts
+++ b/supabase/functions/_shared/feed/nitter.ts
@@ -264,7 +264,7 @@ const getMedia = (entry: FeedEntry): string[] | undefined => {
     let matches;
 
     do {
-      matches = re.exec(entry.description?.value);
+      matches = re.exec(unescape(entry.description.value));
       if (
         matches && matches.length == 2
       ) {

--- a/supabase/functions/_shared/feed/rss.ts
+++ b/supabase/functions/_shared/feed/rss.ts
@@ -357,7 +357,7 @@ const getMedia = (entry: FeedEntry): string | undefined => {
 
   if (entry.description?.value) {
     const matches = /<img[^>]+\bsrc=["']([^"']+)["']/.exec(
-      entry.description?.value,
+      unescape(entry.description.value),
     );
     if (
       matches && matches.length == 2 && matches[1].startsWith('https://') &&
@@ -369,7 +369,7 @@ const getMedia = (entry: FeedEntry): string | undefined => {
 
   if (entry.content?.value) {
     const matches = /<img[^>]+\bsrc=["']([^"']+)["']/.exec(
-      entry.content?.value,
+      unescape(entry.content.value),
     );
     if (
       matches && matches.length == 2 && matches[1].startsWith('https://') &&

--- a/supabase/functions/_shared/feed/tumblr.ts
+++ b/supabase/functions/_shared/feed/tumblr.ts
@@ -180,7 +180,7 @@ const generateItemId = (sourceId: string, identifier: string): string => {
 const getMedia = (entry: FeedEntry): string | undefined => {
   if (entry.description?.value) {
     const matches = /<img[^>]+\bsrc=["']([^"']+)["']/.exec(
-      unescape(entry.description?.value),
+      unescape(entry.description.value),
     );
     if (matches && matches.length == 2 && matches[1].startsWith('https://')) {
       return matches[1];


### PR DESCRIPTION
In the `getMedia` function for Medium, Nitter, RSS and Tumblr we checked the content and/or description of an RSS feed entry for a media file, but we didn't pass the string to the `unescape` function first, so that we might missed some media files, because our regular expression were not able to find an image.

Now we are using the `unescape` function before using our regular expression to find the image, similar to how we are also applying the `unescape` function before we save the item description.

<!--
  Keep PR title verbose enough and add prefix telling about what source it touches e.g "[rss] Add feature xyz" or if the
  the PR is not realated to a source use "[core]", e.g. "[core] Fix xyz".

  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
