### PR TITLE
[core] Improve Icon Handling

### DIFF
--- a/app/lib/models/source.dart
+++ b/app/lib/models/source.dart
@@ -4,6 +4,7 @@ import 'package:feeddeck/models/sources/github.dart';
 import 'package:feeddeck/models/sources/googlenews.dart';
 import 'package:feeddeck/models/sources/stackoverflow.dart';
 import 'package:feeddeck/utils/constants.dart';
+import 'package:feeddeck/utils/fd_icons.dart';
 
 /// [FDSourceType] is a enum value which defines the source type. A source can
 /// have one of the following types:
@@ -85,9 +86,42 @@ extension FDSourceTypeExtension on FDSourceType {
     }
   }
 
-  /// [color] returns the brand color for a source type, which can be used as
-  /// background color for the icon of a source type.
-  Color get color {
+  /// [icon] returns the icon for a source.
+  IconData get icon {
+    switch (this) {
+      case FDSourceType.github:
+        return FDIcons.github;
+      case FDSourceType.googlenews:
+        return FDIcons.googlenews;
+      case FDSourceType.mastodon:
+        return FDIcons.mastodon;
+      case FDSourceType.medium:
+        return FDIcons.medium;
+      case FDSourceType.nitter:
+        return FDIcons.nitter;
+      case FDSourceType.pinterest:
+        return FDIcons.pinterest;
+      case FDSourceType.podcast:
+        return Icons.podcasts;
+      case FDSourceType.reddit:
+        return FDIcons.reddit;
+      case FDSourceType.rss:
+        return FDIcons.rss;
+      case FDSourceType.stackoverflow:
+        return FDIcons.stackoverflow;
+      case FDSourceType.tumblr:
+        return FDIcons.tumblr;
+      // case FDSourceType.x:
+      //   return FDIcons.x;
+      case FDSourceType.youtube:
+        return FDIcons.youtube;
+      default:
+        return FDIcons.feeddeck;
+    }
+  }
+
+  /// [bgColor] returns the background color for the source icon.
+  Color get bgColor {
     switch (this) {
       case FDSourceType.github:
         return const Color(0xff000000);
@@ -117,6 +151,41 @@ extension FDSourceTypeExtension on FDSourceType {
         return const Color(0xffff0000);
       default:
         return Constants.primary;
+    }
+  }
+
+  /// [fgColor] returns the forground color for the source icon. This should be
+  /// used toether with the [bgColor].
+  Color get fgColor {
+    switch (this) {
+      case FDSourceType.github:
+        return const Color(0xffffffff);
+      case FDSourceType.googlenews:
+        return const Color(0xffffffff);
+      case FDSourceType.mastodon:
+        return const Color(0xffffffff);
+      case FDSourceType.medium:
+        return const Color(0xffffffff);
+      case FDSourceType.nitter:
+        return const Color(0xffffffff);
+      case FDSourceType.pinterest:
+        return const Color(0xffffffff);
+      case FDSourceType.podcast:
+        return const Color(0xffffffff);
+      case FDSourceType.reddit:
+        return const Color(0xffffffff);
+      case FDSourceType.rss:
+        return const Color(0xffffffff);
+      case FDSourceType.stackoverflow:
+        return const Color(0xffffffff);
+      case FDSourceType.tumblr:
+        return const Color(0xffffffff);
+      // case FDSourceType.x:
+      //   return const Color(0xffffffff);
+      case FDSourceType.youtube:
+        return const Color(0xffffffff);
+      default:
+        return Constants.onPrimary;
     }
   }
 }

--- a/app/lib/widgets/source/add/add_source.dart
+++ b/app/lib/widgets/source/add/add_source.dart
@@ -1,4 +1,3 @@
-import 'package:feeddeck/widgets/source/add/add_source_pinterest.dart';
 import 'package:flutter/material.dart';
 
 import 'package:feeddeck/models/column.dart';
@@ -9,6 +8,7 @@ import 'package:feeddeck/widgets/source/add/add_source_googlenews.dart';
 import 'package:feeddeck/widgets/source/add/add_source_mastodon.dart';
 import 'package:feeddeck/widgets/source/add/add_source_medium.dart';
 import 'package:feeddeck/widgets/source/add/add_source_nitter.dart';
+import 'package:feeddeck/widgets/source/add/add_source_pinterest.dart';
 import 'package:feeddeck/widgets/source/add/add_source_podcast.dart';
 import 'package:feeddeck/widgets/source/add/add_source_reddit.dart';
 import 'package:feeddeck/widgets/source/add/add_source_rss.dart';
@@ -120,7 +120,7 @@ class _AddSourceState extends State<AddSource> {
                 /// If we decide later to use a generic color as background
                 /// the following line can be used:
                 /// color: Constants.secondary,
-                color: FDSourceType.values[index].color,
+                color: FDSourceType.values[index].bgColor,
                 borderRadius: BorderRadius.circular(4),
               ),
               child: Column(
@@ -137,14 +137,14 @@ class _AddSourceState extends State<AddSource> {
                   ),
                   Text(
                     FDSourceType.values[index].toLocalizedString(),
-                    style: const TextStyle(
+                    style: TextStyle(
                       /// Since we are using the brand color as background
                       /// color, we are using the same color as for the icon
                       /// as text color (source_icon.dart). If we decide later
                       /// to use a generic color as background the following
                       /// line can be used:
                       /// color: Constants.onSecondary,
-                      color: Color(0xffffffff),
+                      color: FDSourceType.values[index].fgColor,
                     ),
                   ),
                 ],

--- a/app/lib/widgets/source/source_icon.dart
+++ b/app/lib/widgets/source/source_icon.dart
@@ -43,106 +43,21 @@ class SourceIcon extends StatelessWidget {
 
   /// [buildDefaultIcon] returns an icon based on the provided source [type].
   Widget buildDefaultIcon(double iconSize) {
-    switch (type) {
-      case FDSourceType.github:
-        return buildIcon(
-          FDIcons.github,
-          iconSize,
-          type.color,
-          const Color(0xffffffff),
-        );
-      case FDSourceType.googlenews:
-        return buildIcon(
-          FDIcons.googlenews,
-          iconSize,
-          type.color,
-          const Color(0xffffffff),
-        );
-      case FDSourceType.mastodon:
-        return buildIcon(
-          FDIcons.mastodon,
-          iconSize,
-          type.color,
-          const Color(0xffffffff),
-        );
-      case FDSourceType.medium:
-        return buildIcon(
-          FDIcons.medium,
-          iconSize,
-          type.color,
-          const Color(0xffffffff),
-        );
-      case FDSourceType.nitter:
-        return buildIcon(
-          FDIcons.nitter,
-          iconSize,
-          type.color,
-          const Color(0xffffffff),
-        );
-      case FDSourceType.pinterest:
-        return buildIcon(
-          FDIcons.pinterest,
-          iconSize,
-          type.color,
-          const Color(0xffffffff),
-        );
-      case FDSourceType.podcast:
-        return buildIcon(
-          Icons.podcasts,
-          iconSize,
-          type.color,
-          const Color(0xffffffff),
-        );
-      case FDSourceType.reddit:
-        return buildIcon(
-          FDIcons.reddit,
-          iconSize,
-          type.color,
-          const Color(0xffffffff),
-        );
-      case FDSourceType.rss:
-        return buildIcon(
-          FDIcons.rss,
-          iconSize,
-          type.color,
-          const Color(0xffffffff),
-        );
-      case FDSourceType.stackoverflow:
-        return buildIcon(
-          FDIcons.stackoverflow,
-          iconSize,
-          type.color,
-          const Color(0xffffffff),
-        );
-      case FDSourceType.tumblr:
-        return buildIcon(
-          FDIcons.tumblr,
-          iconSize,
-          type.color,
-          const Color(0xffffffff),
-        );
-      // case FDSourceType.x:
-      //   return buildIcon(
-      //     FDIcons.x,
-      //     iconSize,
-      //     type.color,
-      //     const Color(0xffffffff),
-      //   );
-      case FDSourceType.youtube:
-        return buildIcon(
-          FDIcons.youtube,
-          iconSize,
-          type.color,
-          const Color(0xffffffff),
-        );
-      default:
-        return buildIcon(
-          FDIcons.feeddeck,
-          iconSize,
-          Constants.primary,
-          Constants.onPrimary,
-        );
+    if (FDSourceType.values.contains(type)) {
+      return buildIcon(
+        type.icon,
+        iconSize,
+        type.bgColor,
+        type.fgColor,
+      );
     }
+
+    return buildIcon(
+      FDIcons.feeddeck,
+      iconSize,
+      Constants.primary,
+      Constants.onPrimary,
+    );
   }
 
   @override


### PR DESCRIPTION
Instead of defining the icons for a source only within the `SourceIcon` widget, the icons are now defined as extension for the `FDSourceType` enum. The background and foreground colors are also defined within the enum now. This allows us to access the icon of a source outside of the `SourceIcon` widget and we only have to touch the `source.dart` file when adding a new source type.

<!--
  Keep PR title verbose enough and add prefix telling about what source it touches e.g "[rss] Add feature xyz" or if the
  the PR is not realated to a source use "[core]", e.g. "[core] Fix xyz".

  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
