### PR TITLE
[reddit] Remove Tables from Description

### DIFF
--- a/supabase/functions/_shared/feed/reddit.ts
+++ b/supabase/functions/_shared/feed/reddit.ts
@@ -116,9 +116,7 @@ export const getRedditFeed = async (
       title: entry.title!.value!,
       link: entry.links[0].href!,
       media: getMedia(entry),
-      description: entry.content?.value
-        ? unescape(entry.content.value)
-        : undefined,
+      description: getDescription(entry),
       author: entry.author?.name,
       publishedAt: Math.floor(entry.published!.getTime() / 1000),
     });
@@ -180,6 +178,27 @@ const generateSourceId = (
  */
 const generateItemId = (sourceId: string, identifier: string): string => {
   return `${sourceId}-${new Md5().update(identifier).toString()}`;
+};
+
+/**
+ * `getDescription` returns the description for a feed entry. If the entry does
+ * not contain a description we return `undefined`. Some Reddit feed items are
+ * containing a table, which we have to remove from the description, to improve
+ * the rendering in the Flutter app.
+ */
+const getDescription = (entry: FeedEntry): string | undefined => {
+  if (entry.content?.value) {
+    const content = unescape(entry.content.value);
+    return content.replaceAll('<table>', '').replaceAll('<tr>', '').replaceAll(
+      '<td>',
+      '',
+    ).replaceAll('</table>', '').replaceAll('</tr>', '').replaceAll(
+      '</td>',
+      '',
+    );
+  }
+
+  return undefined;
 };
 
 /**


### PR DESCRIPTION
When a Reddit post contained an image it was always rendered as table, where the image was displayed in the left column and the author in the right column. This looked very ugly in the app, so that we are now removing all tables from the description of an Reddit post, so that the image is rendered as large as possible and the author is displayed below the image.

<!--
  Keep PR title verbose enough and add prefix telling about what source it touches e.g "[rss] Add feature xyz" or if the
  the PR is not realated to a source use "[core]", e.g. "[core] Fix xyz".

  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
