### PR TITLE
[core] Fix `build.gradle` File for Android Release

### DIFF
--- a/app/android/app/build.gradle
+++ b/app/android/app/build.gradle
@@ -71,7 +71,7 @@ android {
 
     buildTypes {
         release {
-            if (project.hasProperty("keyStoreFile")) {
+            if (keystorePropertiesFile.exists()) {
                 signingConfig signingConfigs.release
             } else {
                 // For testing purposes we sign with dummy credentials if no key properties are given.


### PR DESCRIPTION
The change introduced in #71 so that we can run the Android build in a GitHub action, broke the `flutter build appbundle` command to build the Android version for the Google Play store. This commit should fix this, so that we can build the Android version in a GitHub Action and for Google Play.

<!--
  Keep PR title verbose enough and add prefix telling about what source it touches e.g "[rss] Add feature xyz" or if the
  the PR is not realated to a source use "[core]", e.g. "[core] Fix xyz".

  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
