### PR TITLE
[podcast] Stop Audio Playback on Windows and Linux

### DIFF
--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -57,7 +57,7 @@ void main() async {
   /// We can not initialize the [just_audio_background] package on Windows and
   /// Linux, because then the returned duration in the `_player.durationStream`
   /// isn't working correctly in the [ItemAudioPlayer] widget.
-  if (kIsWeb || Platform.isAndroid || Platform.isIOS || Platform.isIOS) {
+  if (kIsWeb || Platform.isAndroid || Platform.isIOS || Platform.isMacOS) {
     await JustAudioBackground.init(
       androidNotificationChannelId: 'com.ryanheise.bg_demo.channel.audio',
       androidNotificationChannelName: 'Audio playback',

--- a/app/lib/widgets/item/details/utils/item_audio_palyer/item_audio_player.dart
+++ b/app/lib/widgets/item/details/utils/item_audio_palyer/item_audio_player.dart
@@ -65,6 +65,7 @@ class _ItemAudioPlayerState extends State<ItemAudioPlayer> {
 
   @override
   void dispose() {
+    _player.pause();
     _player.dispose();
     super.dispose();
   }


### PR DESCRIPTION
On Windows and Linux it could happen that the audio playback for a podcast wasn't stopped when the item details view for a podcast item was closed.

This commit "fixes" the problem, by pausing the audio player, before the widget is disposed.

This commit also fixes the condition when the background audio services should be initialized in the `main.dart` file. Instead of the macOS check, we checked for iOS twice.

<!--
  Keep PR title verbose enough and add prefix telling about what source it touches e.g "[rss] Add feature xyz" or if the
  the PR is not realated to a source use "[core]", e.g. "[core] Fix xyz".

  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
