### PR TITLE
[core] Remove Blank in Item Preview Description

### DIFF
--- a/app/lib/widgets/item/preview/utils/item_description.dart
+++ b/app/lib/widgets/item/preview/utils/item_description.dart
@@ -81,6 +81,10 @@ class ItemDescription extends StatelessWidget {
   }
 
   /// [_buildPlain] renders the provided [content] as plain text.
+  ///
+  /// To not have some trailing newlines, the [content] is trimmed and splitted
+  /// on newline characters, so that we can filter out empty lines, before the
+  /// the content is rendered.
   Widget _buildPlain(String content) {
     if (content == '') {
       return Container();
@@ -91,7 +95,7 @@ class ItemDescription extends StatelessWidget {
         bottom: Constants.spacingExtraSmall,
       ),
       child: Text(
-        content.trim(),
+        content.trim().split('\n').where((line) => line != '').join('\n'),
         maxLines: 5,
         style: const TextStyle(
           overflow: TextOverflow.ellipsis,


### PR DESCRIPTION
This commit removes all blank lines in the item preview description, so that we do not render a blank line as the last line. This was done to improve the style of the item previews, which looked ugly when the last line was a blank line.

<!--
  Keep PR title verbose enough and add prefix telling about what source it touches e.g "[rss] Add feature xyz" or if the
  the PR is not realated to a source use "[core]", e.g. "[core] Fix xyz".

  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
