### PR TITLE
[core] Fix Index Reset for Tabs in Small Deck Layout

### DIFF
--- a/app/lib/widgets/deck/deck_layout_small.dart
+++ b/app/lib/widgets/deck/deck_layout_small.dart
@@ -149,6 +149,7 @@ class DeckLayoutSmall extends StatelessWidget {
     AppRepository app = Provider.of<AppRepository>(context, listen: true);
 
     return DefaultTabController(
+      key: ValueKey(app.activeDeckId),
       initialIndex: _getInitialIndex(context, app.columns.length),
       length: app.columns.length,
       child: Scaffold(


### PR DESCRIPTION
The index was not reset in the `DeckLayoutSmall` widget, when the user selected a new deck in the settings widget. This was caused because the `DefaultTabController` was not rebuild after a new deck was selected, so that the `initialIndex` value was not used.

This is now fixed by adding a `key` to the `DefaultTabController`, which corresponds to the selected deck. This means if the user selects a new deck in the settings the widget will be rebuild and the initial selected tab will be the first one. If a user selects the same deck or switches between the small and large layout the tab will be the formerly selected one.

<!--
  Keep PR title verbose enough and add prefix telling about what source it touches e.g "[rss] Add feature xyz" or if the
  the PR is not realated to a source use "[core]", e.g. "[core] Fix xyz".

  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
