### PR TITLE
[core] Improve `ItemVideoPlayer` Widget

### DIFF
--- a/app/lib/widgets/item/details/item_details_lemmy.dart
+++ b/app/lib/widgets/item/details/item_details_lemmy.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 
 import 'package:feeddeck/models/item.dart';
 import 'package:feeddeck/models/source.dart';
-import 'package:feeddeck/utils/constants.dart';
 import 'package:feeddeck/widgets/item/details/utils/item_description.dart';
 import 'package:feeddeck/widgets/item/details/utils/item_media.dart';
 import 'package:feeddeck/widgets/item/details/utils/item_subtitle.dart';
@@ -39,13 +38,8 @@ class ItemDetailsLemmy extends StatelessWidget {
       }
 
       if (mediaUrl.path.endsWith('.mp4')) {
-        return Container(
-          padding: const EdgeInsets.only(
-            bottom: Constants.spacingMiddle,
-          ),
-          child: ItemVideoPlayer(
-            video: item.media!,
-          ),
+        return ItemVideoPlayer(
+          video: item.media!,
         );
       }
 

--- a/app/lib/widgets/item/details/utils/item_videos.dart
+++ b/app/lib/widgets/item/details/utils/item_videos.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
@@ -25,22 +26,12 @@ class ItemVideos extends StatelessWidget {
       return Container();
     }
 
-    return Container(
-      padding: const EdgeInsets.only(
-        bottom: Constants.spacingMiddle,
-      ),
-      child: ListView.separated(
-        shrinkWrap: true,
-        separatorBuilder: (context, index) {
-          return const SizedBox(
-            height: Constants.spacingMiddle,
-          );
-        },
-        itemCount: videos!.length,
-        itemBuilder: (context, index) {
-          return ItemVideoPlayer(video: videos![index]);
-        },
-      ),
+    return ListView.builder(
+      shrinkWrap: true,
+      itemCount: videos!.length,
+      itemBuilder: (context, index) {
+        return ItemVideoPlayer(video: videos![index]);
+      },
     );
   }
 }
@@ -113,29 +104,50 @@ class _ItemVideoPlayerState extends State<ItemVideoPlayer> {
                   Radius.circular(Constants.spacingMiddle),
                 ),
               ),
-              child: ListView.separated(
-                shrinkWrap: true,
-                separatorBuilder: (context, index) {
-                  return const Divider(
-                    color: Constants.dividerColor,
-                    height: 1,
-                    thickness: 1,
-                  );
-                },
-                itemCount: widget.qualities!.length,
-                itemBuilder: (context, index) {
-                  return ListTile(
-                    mouseCursor: SystemMouseCursors.click,
-                    onTap: () {
-                      Navigator.of(context).pop();
-                      player.open(
-                        Media(widget.qualities![index].video),
-                        play: true,
-                      );
-                    },
-                    title: Text(widget.qualities![index].quality),
-                  );
-                },
+              child: Wrap(
+                alignment: WrapAlignment.center,
+                crossAxisAlignment: WrapCrossAlignment.center,
+                children: widget.qualities!
+                    .asMap()
+                    .entries
+                    .map((quality) {
+                      if (quality.key == widget.qualities!.length - 1) {
+                        return [
+                          ListTile(
+                            mouseCursor: SystemMouseCursors.click,
+                            onTap: () {
+                              Navigator.of(context).pop();
+                              player.open(
+                                Media(quality.value.video),
+                                play: true,
+                              );
+                            },
+                            title: Text(quality.value.quality),
+                          ),
+                        ];
+                      }
+
+                      return [
+                        ListTile(
+                          mouseCursor: SystemMouseCursors.click,
+                          onTap: () {
+                            Navigator.of(context).pop();
+                            player.open(
+                              Media(quality.value.video),
+                              play: true,
+                            );
+                          },
+                          title: Text(quality.value.quality),
+                        ),
+                        const Divider(
+                          color: Constants.dividerColor,
+                          height: 1,
+                          thickness: 1,
+                        ),
+                      ];
+                    })
+                    .expand((e) => e)
+                    .toList(),
               ),
             );
           },
@@ -211,46 +223,51 @@ class _ItemVideoPlayerState extends State<ItemVideoPlayer> {
 
   @override
   Widget build(BuildContext context) {
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        return Center(
-          child: SizedBox(
-            width: constraints.maxWidth,
-            height: constraints.maxWidth * 9.0 / 16.0,
-            child: MaterialDesktopVideoControlsTheme(
-              normal: MaterialDesktopVideoControlsThemeData(
-                bottomButtonBar: _buildBottomButtonBar(false),
-                seekBarPositionColor: Constants.primary,
-                seekBarThumbColor: Constants.primary,
-              ),
-              fullscreen: const MaterialDesktopVideoControlsThemeData(
-                seekBarPositionColor: Constants.primary,
-                seekBarThumbColor: Constants.primary,
-              ),
-              child: MaterialVideoControlsTheme(
-                normal: MaterialVideoControlsThemeData(
-                  bottomButtonBar: _buildBottomButtonBar(true),
+    return Container(
+      padding: const EdgeInsets.only(
+        bottom: Constants.spacingMiddle,
+      ),
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          return Center(
+            child: SizedBox(
+              width: constraints.maxWidth,
+              height: constraints.maxWidth * 9.0 / 16.0,
+              child: MaterialDesktopVideoControlsTheme(
+                normal: MaterialDesktopVideoControlsThemeData(
+                  bottomButtonBar: _buildBottomButtonBar(false),
                   seekBarPositionColor: Constants.primary,
                   seekBarThumbColor: Constants.primary,
                 ),
-                fullscreen: const MaterialVideoControlsThemeData(
+                fullscreen: const MaterialDesktopVideoControlsThemeData(
                   seekBarPositionColor: Constants.primary,
                   seekBarThumbColor: Constants.primary,
                 ),
-                child: Video(
-                  controller: controller,
-                  controls: kIsWeb ||
-                          Platform.isLinux ||
-                          Platform.isMacOS ||
-                          Platform.isWindows
-                      ? MaterialDesktopVideoControls
-                      : MaterialVideoControls,
+                child: MaterialVideoControlsTheme(
+                  normal: MaterialVideoControlsThemeData(
+                    bottomButtonBar: _buildBottomButtonBar(true),
+                    seekBarPositionColor: Constants.primary,
+                    seekBarThumbColor: Constants.primary,
+                  ),
+                  fullscreen: const MaterialVideoControlsThemeData(
+                    seekBarPositionColor: Constants.primary,
+                    seekBarThumbColor: Constants.primary,
+                  ),
+                  child: Video(
+                    controller: controller,
+                    controls: kIsWeb ||
+                            Platform.isLinux ||
+                            Platform.isMacOS ||
+                            Platform.isWindows
+                        ? MaterialDesktopVideoControls
+                        : MaterialVideoControls,
+                  ),
                 ),
               ),
             ),
-          ),
-        );
-      },
+          );
+        },
+      ),
     );
   }
 }

--- a/app/lib/widgets/item/details/utils/item_youtube/item_youtube_video_native.dart
+++ b/app/lib/widgets/item/details/utils/item_youtube/item_youtube_video_native.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 
 import 'package:youtube_explode_dart/youtube_explode_dart.dart';
 
-import 'package:feeddeck/utils/constants.dart';
 import 'package:feeddeck/widgets/item/details/utils/item_media.dart';
 import 'package:feeddeck/widgets/item/details/utils/item_videos.dart';
 import 'item_youtube_video.dart';
@@ -70,14 +69,9 @@ class _ItemYoutubeVideoNativeState extends State<ItemYoutubeVideoNative> {
           return ItemMedia(itemMedia: widget.imageUrl);
         }
 
-        return Container(
-          padding: const EdgeInsets.only(
-            bottom: Constants.spacingMiddle,
-          ),
-          child: ItemVideoPlayer(
-            video: snapshot.data!.first.video,
-            qualities: snapshot.data,
-          ),
+        return ItemVideoPlayer(
+          video: snapshot.data!.first.video,
+          qualities: snapshot.data,
         );
       },
     );


### PR DESCRIPTION
This commit adds two improvements to the `ItemVideoPlayer` widget. These improvements are:
1. The padding for the widget is now defined within the widget, so that is must not be defined in the parent widget. With this change the widget follows the styling of our other widgets like `ItemMedia`.
2. On iOS the quality selection had a large bottom padding, this is now fixed, by using a `Wrap` widget instead of a `ListView` like we are using in the other modal bottom sheets which are showing some actions.

<!--
  Keep PR title verbose enough and add prefix telling about what source it touches e.g "[rss] Add feature xyz" or if the
  the PR is not realated to a source use "[core]", e.g. "[core] Fix xyz".

  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
