### PR TITLE
[core] Fix Converting of HTML to Plain Text in Description

### DIFF
--- a/app/lib/widgets/item/details/utils/item_description.dart
+++ b/app/lib/widgets/item/details/utils/item_description.dart
@@ -158,7 +158,9 @@ class ItemDescription extends StatelessWidget {
     if (sourceFormat == DescriptionFormat.html &&
         tagetFormat == DescriptionFormat.plain) {
       return _buildPlain(
-        itemDescription!.replaceAll(RegExp(r'<[^>]*>|&[^;]+;'), ''),
+        itemDescription!
+            .replaceAll(RegExp(r'<[^>]*>|&[^;]+;'), ' ')
+            .replaceAll(RegExp('\\s+'), ' '),
       );
     }
 

--- a/app/lib/widgets/item/preview/utils/item_description.dart
+++ b/app/lib/widgets/item/preview/utils/item_description.dart
@@ -125,7 +125,9 @@ class ItemDescription extends StatelessWidget {
     if (sourceFormat == DescriptionFormat.html &&
         tagetFormat == DescriptionFormat.plain) {
       return _buildPlain(
-        itemDescription!.replaceAll(RegExp(r'<[^>]*>|&[^;]+;'), ''),
+        itemDescription!
+            .replaceAll(RegExp(r'<[^>]*>|&[^;]+;'), ' ')
+            .replaceAll(RegExp('\\s+'), ' '),
       );
     }
 


### PR DESCRIPTION
This commit fixes the conversion of HTML to plain text in the description for an item. Until now it could happen, that the there was no whitespace between some words after the conversion. This is now fixed so that there is always a whitespace between words in the plain text.

<!--
  Keep PR title verbose enough and add prefix telling about what source it touches e.g "[rss] Add feature xyz" or if the
  the PR is not realated to a source use "[core]", e.g. "[core] Fix xyz".

  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
