### PR TITLE
[rss] Parse Atom and RDF Feeds from Websites

### DIFF
--- a/supabase/functions/_shared/feed/rss.ts
+++ b/supabase/functions/_shared/feed/rss.ts
@@ -202,9 +202,15 @@ const getFeedFromWebsite = async (
     const html = await response.text();
 
     const $ = cheerio.load(html);
-    const rssLink = $('link[type="application/rss+xml"]').attr('href');
+    let rssLink = $('link[type="application/rss+xml"]').attr('href');
     if (!rssLink) {
-      return undefined;
+      rssLink = $('link[type="application/atom+xml"]').attr('href');
+      if (!rssLink) {
+        rssLink = $('link[type="application/rdf+xml"]').attr('href');
+        if (!rssLink) {
+          return undefined;
+        }
+      }
     }
     source.options!.rss = new URL(rssLink, source.options!.rss!).href;
 


### PR DESCRIPTION
Until now we only checked if a website contained a RSS feed which can be used for FeedDeck. Now we are also checking if the website contains a Atom or RDF feed when no RSS feed was found.

For this we are checking `link` tag with the `type="application/atom+xml"` attribute or a link tag with the `type="application/rdf+xml"` attribute.

<!--
  Keep PR title verbose enough and add prefix telling about what source it touches e.g "[rss] Add feature xyz" or if the
  the PR is not realated to a source use "[core]", e.g. "[core] Fix xyz".

  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
