### PR TITLE
[core] Disable Right Click for Item Actions on Web

### DIFF
--- a/app/lib/widgets/item/preview/utils/item_actions.dart
+++ b/app/lib/widgets/item/preview/utils/item_actions.dart
@@ -339,8 +339,9 @@ class _ItemActionsState extends State<ItemActions> {
         onTap: widget.onTap,
         onTapDown: (details) => _getTapPositionLarge(details),
         onLongPress: () => _showActionsMenuLarge(context),
-        onSecondaryTapDown: (details) => _getTapPositionLarge(details),
-        onSecondaryTap: () => _showActionsMenuLarge(context),
+        onSecondaryTapDown:
+            kIsWeb ? null : (details) => _getTapPositionLarge(details),
+        onSecondaryTap: kIsWeb ? null : () => _showActionsMenuLarge(context),
         child: Container(
           width: double.infinity,
           decoration: const BoxDecoration(


### PR DESCRIPTION
On the web the right click on an item to show the actions, doesn't work properly, because the browsers right click menu will be shown first. So it doesn't make sense to show also our right click menu.

<!--
  Keep PR title verbose enough and add prefix telling about what source it touches e.g "[rss] Add feature xyz" or if the
  the PR is not realated to a source use "[core]", e.g. "[core] Fix xyz".

  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
