### PR TITLE
[core] Replace Deprecated `serve` Function

### DIFF
--- a/supabase/functions/add-source-v1/index.ts
+++ b/supabase/functions/add-source-v1/index.ts
@@ -1,4 +1,3 @@
-import { serve } from 'std/server';
 import { createClient } from '@supabase/supabase-js';
 
 import { corsHeaders } from '../_shared/utils/cors.ts';
@@ -19,7 +18,7 @@ import {
  * column id, source type and options. The function will return the source
  * object as it was added to the database.
  */
-serve(async (req) => {
+Deno.serve(async (req) => {
   /**
    * We need to handle the preflight request for CORS as it is described in the
    * Supabase documentation: https://supabase.com/docs/guides/functions/cors

--- a/supabase/functions/delete-user-v1/index.ts
+++ b/supabase/functions/delete-user-v1/index.ts
@@ -1,4 +1,3 @@
-import { serve } from 'std/server';
 import { createClient } from '@supabase/supabase-js';
 
 import { corsHeaders } from '../_shared/utils/cors.ts';
@@ -14,7 +13,7 @@ import {
  *  the user is deleted all the corresponding user data is also removed, so that
  * we should warn a user about this action.
  */
-serve(async (req) => {
+Deno.serve(async (req) => {
   /**
    * We need to handle the preflight request for CORS as it is described in the
    * Supabase documentation: https://supabase.com/docs/guides/functions/cors

--- a/supabase/functions/generate-magic-link-v1/index.ts
+++ b/supabase/functions/generate-magic-link-v1/index.ts
@@ -1,4 +1,3 @@
-import { serve } from 'std/server';
 import { createClient } from '@supabase/supabase-js';
 
 import { corsHeaders } from '../_shared/utils/cors.ts';
@@ -15,7 +14,7 @@ import {
  * column id, source type and options. The function will return the source
  * object as it was added to the database.
  */
-serve(async (req) => {
+Deno.serve(async (req) => {
   /**
    * We need to handle the preflight request for CORS as it is described in the
    * Supabase documentation: https://supabase.com/docs/guides/functions/cors

--- a/supabase/functions/image-proxy-v1/index.ts
+++ b/supabase/functions/image-proxy-v1/index.ts
@@ -1,5 +1,3 @@
-import { serve } from 'std/server';
-
 import { FEEDDECK_SUPABASE_SITE_URL } from '../_shared/utils/constants.ts';
 import { log } from '../_shared/utils/log.ts';
 import { fetchWithTimeout } from '../_shared/utils/fetchWithTimeout.ts';
@@ -14,7 +12,7 @@ const imageCorsHeaders = {
  * The `image-proxy-v1` edge function is used to proxy images from external
  * sources. This is required to avoid CORS errors in the web app.
  */
-serve(async (req) => {
+Deno.serve(async (req) => {
   if (req.method === 'OPTIONS') {
     return new Response('ok', { headers: imageCorsHeaders });
   }

--- a/supabase/functions/import_map.json
+++ b/supabase/functions/import_map.json
@@ -2,7 +2,6 @@
   "imports": {
     "std/assert": "https://deno.land/std@0.208.0/assert/mod.ts",
     "std/testing/mock": "https://deno.land/std@0.208.0/testing/mock.ts",
-    "std/server": "https://deno.land/std@0.208.0/http/server.ts",
     "std/hex": "https://deno.land/std@0.208.0/encoding/hex.ts",
     "std/crypto": "https://deno.land/std@0.208.0/crypto/mod.ts",
     "@supabase/supabase-js": "https://esm.sh/@supabase/supabase-js@2.39.0",

--- a/supabase/functions/profile-v1/index.ts
+++ b/supabase/functions/profile-v1/index.ts
@@ -1,4 +1,3 @@
-import { serve } from 'std/server';
 import { createClient } from '@supabase/supabase-js';
 
 import { corsHeaders } from '../_shared/utils/cors.ts';
@@ -16,7 +15,7 @@ import {
  * DEPRECATED: This function is deprecated and will be removed in the future.
  * Please use the new `profile-v2` function.
  */
-serve(async (req) => {
+Deno.serve(async (req) => {
   /**
    * We need to handle the preflight request for CORS as it is described in the
    * Supabase documentation: https://supabase.com/docs/guides/functions/cors

--- a/supabase/functions/profile-v2/index.ts
+++ b/supabase/functions/profile-v2/index.ts
@@ -1,4 +1,3 @@
-import { serve } from 'std/server';
 import { createClient, SupabaseClient, User } from '@supabase/supabase-js';
 
 import { corsHeaders } from '../_shared/utils/cors.ts';
@@ -73,7 +72,7 @@ const getProfile = async (
  * related to the users profile. This means that the function can be used to get
  * the users profile and to handle the users connected accounts.
  */
-serve(async (req) => {
+Deno.serve(async (req) => {
   const { url, method } = req;
 
   /**

--- a/supabase/functions/revenuecat-webhooks-v1/index.ts
+++ b/supabase/functions/revenuecat-webhooks-v1/index.ts
@@ -1,4 +1,3 @@
-import { serve } from 'std/server';
 import { createClient } from '@supabase/supabase-js';
 
 import { log } from '../_shared/utils/log.ts';
@@ -114,7 +113,7 @@ export const manageSubscriptionStatusChange = async (
  * webhooks. When we a receive a new event, we have to change the users account
  * tier to `premium` or to `free`, depending on the received event.
  */
-serve(async (req) => {
+Deno.serve(async (req) => {
   try {
     /**
      * If the request method is not POST, we return a 403 Forbidden error. This

--- a/supabase/functions/stripe-create-billing-portal-link-v1/index.ts
+++ b/supabase/functions/stripe-create-billing-portal-link-v1/index.ts
@@ -1,4 +1,3 @@
-import { serve } from 'std/server';
 import { createClient } from '@supabase/supabase-js';
 
 import { corsHeaders } from '../_shared/utils/cors.ts';
@@ -16,7 +15,7 @@ import {
  * The `stripe-create-billing-portal-link-v1` edge function is used to create a
  * link to the Stripe customer portal for the current user.
  */
-serve(async (req) => {
+Deno.serve(async (req) => {
   /**
    * We need to handle the preflight request for CORS as it is described in the
    * Supabase documentation: https://supabase.com/docs/guides/functions/cors

--- a/supabase/functions/stripe-create-checkout-session-v1/index.ts
+++ b/supabase/functions/stripe-create-checkout-session-v1/index.ts
@@ -1,4 +1,3 @@
-import { serve } from 'std/server';
 import { createClient } from '@supabase/supabase-js';
 
 import { corsHeaders } from '../_shared/utils/cors.ts';
@@ -17,7 +16,7 @@ import {
  * Stripe checkout session for the current user. The function returns the URL of
  * the checkout session.
  */
-serve(async (req) => {
+Deno.serve(async (req) => {
   /**
    * We need to handle the preflight request for CORS as it is described in the
    * Supabase documentation: https://supabase.com/docs/guides/functions/cors

--- a/supabase/functions/stripe-webhooks-v1/index.ts
+++ b/supabase/functions/stripe-webhooks-v1/index.ts
@@ -1,4 +1,3 @@
-import { serve } from 'std/server';
 import Stripe from 'stripe';
 
 import { log } from '../_shared/utils/log.ts';
@@ -23,7 +22,7 @@ const relevantEvents = new Set([
  *   stripe login
  *   stripe listen --forward-to http://localhost:54321/functions/v1/stripe-webhooks-v1
  */
-serve(async (req) => {
+Deno.serve(async (req) => {
   try {
     const signature = req.headers.get('Stripe-Signature');
     const body = await req.text();


### PR DESCRIPTION
The used `serve` function from the `std/server` module is deprecated and must be replaced with `Deno.serve`. This was done within this commit.

<!--
  Keep PR title verbose enough and add prefix telling about what source it touches e.g "[rss] Add feature xyz" or if the
  the PR is not realated to a source use "[core]", e.g. "[core] Fix xyz".

  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
