### PR TITLE
[core] Add Additional Headers for Web Deployment

### DIFF
--- a/app/web/_headers
+++ b/app/web/_headers
@@ -1,0 +1,4 @@
+/*
+  X-Content-Type-Options: nosniff
+  X-Frame-Options: DENY
+  Referrer-Policy: no-referrer


### PR DESCRIPTION
This commit adds the `X-Content-Type-Options`, `X-Frame-Options` and `Referrer-Policy` headers to the web deployment of FeedDeck via the `_headers` file.

See https://developers.cloudflare.com/pages/configuration/headers/