### PR TITLE
[core] Add Client Side Scraping of Sources

### DIFF
--- a/.github/workflows/continuous-delivery.yaml
+++ b/.github/workflows/continuous-delivery.yaml
@@ -87,6 +87,7 @@ jobs:
 
           supabase db push
 
+          supabase functions deploy add-or-update-source-v1 --project-ref $PROJECT_ID --import-map supabase/functions/import_map.json
           supabase functions deploy add-source-v1 --project-ref $PROJECT_ID --import-map supabase/functions/import_map.json
           supabase functions deploy delete-user-v1 --project-ref $PROJECT_ID --import-map supabase/functions/import_map.json
           supabase functions deploy generate-magic-link-v1 --project-ref $PROJECT_ID --import-map supabase/functions/import_map.json
@@ -109,6 +110,7 @@ jobs:
 
           supabase db push
 
+          supabase functions deploy add-or-update-source-v1 --project-ref $PROJECT_ID --import-map supabase/functions/import_map.json
           supabase functions deploy add-source-v1 --project-ref $PROJECT_ID --import-map supabase/functions/import_map.json
           supabase functions deploy delete-user-v1 --project-ref $PROJECT_ID --import-map supabase/functions/import_map.json
           supabase functions deploy generate-magic-link-v1 --project-ref $PROJECT_ID --import-map supabase/functions/import_map.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -283,6 +283,7 @@ supabase secrets set --env-file supabase/.env
 supabase secrets list
 
 # Deploy all functions
+supabase functions deploy add-or-update-source-v1 --project-ref <PROJECT-ID> --import-map supabase/functions/import_map.json
 supabase functions deploy add-source-v1 --project-ref <PROJECT-ID> --import-map supabase/functions/import_map.json
 supabase functions deploy delete-user-v1 --project-ref <PROJECT-ID> --import-map supabase/functions/import_map.json
 supabase functions deploy generate-magic-link-v1 --project-ref <PROJECT-ID> --import-map supabase/functions/import_map.json

--- a/app/lib/repositories/app_repository.dart
+++ b/app/lib/repositories/app_repository.dart
@@ -376,21 +376,33 @@ class AppRepository with ChangeNotifier {
   }
 
   /// [addSource] is called to add a source to the column with the provided
-  /// [columnId]. The function takes a [source] as parameter. The function calls
-  /// the `add-source-v1` edge function via the Supabase client to create the
-  /// source. When the source was created the newly returned source is added to
-  /// the list of sources of the column with the provided [columnId].
+  /// [columnId]. Next to [columnId] a user must also provide the [type] and
+  /// [options] for the source. The function calls the `add-or-update-source-v1`
+  /// edge function via the Supabase client to create the source. When the
+  /// source was created the newly returned source is added to the list of
+  /// sources of the column with the provided [columnId].
+  ///
+  /// The optional [feedData] parameter is used to provide the feed data for the
+  /// source. This is can be used to scrape the source data via the client (app)
+  /// instead of the server (scheduler / worker).
   Future<void> addSource(
     String columnId,
     FDSourceType type,
-    FDSourceOptions options,
-  ) async {
+    FDSourceOptions options, [
+    String? feedData,
+  ]) async {
     final result = await Supabase.instance.client.functions.invoke(
-      'add-source-v1',
+      'add-or-update-source-v1',
       body: {
-        'columnId': columnId,
-        'type': type.toShortString(),
-        'options': options.toJson(),
+        'source': {
+          'id': '',
+          'columnId': columnId,
+          'userId': '',
+          'type': type.toShortString(),
+          'title': '',
+          'options': options.toJson(),
+        },
+        'feedData': feedData,
       },
     );
 

--- a/app/lib/utils/get_feed.dart
+++ b/app/lib/utils/get_feed.dart
@@ -1,0 +1,54 @@
+import 'package:feeddeck/models/source.dart';
+import 'package:feeddeck/utils/api_exception.dart';
+import 'package:http/http.dart' as http;
+
+/// [getFeed] returns the feed for the provided [sourceType] and [options]. It
+/// can be used to fetch the feed for a source on the client side (app) instead
+/// of via the corresponding `add-or-update-source-v1` edge function or via our
+/// worker.
+///
+/// The functions for the different sources must implement the same parsing for
+/// the source options as it is done in the edge function.
+Future<String> getFeed(FDSourceType sourceType, FDSourceOptions options) async {
+  switch (sourceType) {
+    case FDSourceType.reddit:
+      return getFeedReddit(options.reddit);
+    default:
+      throw const ApiException('Unknown source type', 400);
+  }
+}
+
+/// [getFeedReddit] returns the feed for the provided [input]. It is used to
+/// fetch the RSS feed for a Reddit source, which can be passed to the
+/// `add-or-update-source-v1` edge function.
+///
+/// The function must implement the same parsing logic as it is done in the
+/// `supabase/functions/_shared/feed/reddit.ts` file.
+Future<String> getFeedReddit(String? input) async {
+  if (input == null || input.isEmpty) {
+    throw const ApiException('No input provided', 400);
+  }
+
+  String url = '';
+  try {
+    if (input.startsWith('/r/') || input.startsWith('/u/')) {
+      url = 'https://www.reddit.com$input.rss';
+    } else {
+      final inputUri = Uri.parse(input);
+      if (inputUri.host.endsWith('reddit.com')) {
+        if (input.endsWith('.rss')) {
+          url = input;
+        } else {
+          url = '$input.rss';
+        }
+      } else {
+        throw const ApiException('Invalid input', 400);
+      }
+    }
+  } catch (err) {
+    throw const ApiException('Invalid input', 400);
+  }
+
+  final response = await http.get(Uri.parse(url));
+  return response.body;
+}

--- a/app/lib/widgets/source/add/add_source_reddit.dart
+++ b/app/lib/widgets/source/add/add_source_reddit.dart
@@ -1,3 +1,5 @@
+import 'package:feeddeck/utils/get_feed.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import 'package:flutter_markdown/flutter_markdown.dart';
@@ -52,12 +54,29 @@ class _AddSourceRedditState extends State<AddSourceReddit> {
 
     try {
       AppRepository app = Provider.of<AppRepository>(context, listen: false);
+
+      /// To avoid getting rate limited by Reddit, we already fetch the feed
+      /// here and send it to the Supabase edge function within the [data]
+      /// field.
+      /// Since this only works for the desktop and mobile clients, we have to
+      /// check if the user is on the web, so that we can still try to fetch the
+      /// feed in the edge function.
+      final feedData = kIsWeb
+          ? null
+          : await getFeed(
+              FDSourceType.reddit,
+              FDSourceOptions(
+                reddit: _redditController.text,
+              ),
+            );
+
       await app.addSource(
         widget.column.id,
         FDSourceType.reddit,
         FDSourceOptions(
           reddit: _redditController.text,
         ),
+        feedData,
       );
       setState(() {
         _isLoading = false;

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -170,7 +170,7 @@ packages:
     source: hosted
     version: "3.1.1"
   crypto:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: crypto
       sha256: ff625774173754681d66daaf4a448684fb04b78f902da9cb3d308c19cc5e8bab
@@ -353,7 +353,7 @@ packages:
     source: hosted
     version: "1.3.1"
   http:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: http
       sha256: d4872660c46d929f6b8a9ef4e7a7eff7e49bbf0c4ec3f385ee32df5119175139

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -47,6 +47,7 @@ dependencies:
   flutter_native_splash: ^2.3.5
   html: ^0.15.4
   html2md: ^1.2.6
+  http: ^1.1.2
   intl: ^0.18.1
   just_audio: ^0.9.32
   just_audio_background: ^0.0.1-beta.10

--- a/supabase/functions/_cmd/scheduler/scheduler.ts
+++ b/supabase/functions/_cmd/scheduler/scheduler.ts
@@ -157,7 +157,6 @@ const scheduleSources = async (
             'profile': profile.id,
           });
           await redisClient.rpush(
-            // source.id,
             'sources',
             JSON.stringify({
               source: source,

--- a/supabase/functions/_shared/feed/feed.ts
+++ b/supabase/functions/_shared/feed/feed.ts
@@ -30,83 +30,123 @@ export const getFeed = async (
   redisClient: Redis | undefined,
   profile: IProfile,
   source: ISource,
+  feedData: string | undefined,
 ): Promise<{ source: ISource; items: IItem[] }> => {
   switch (source.type) {
     case 'github':
-      return await getGithubFeed(supabaseClient, redisClient, profile, source);
+      return await getGithubFeed(
+        supabaseClient,
+        redisClient,
+        profile,
+        source,
+        feedData,
+      );
     case 'googlenews':
       return await getGooglenewsFeed(
         supabaseClient,
         redisClient,
         profile,
         source,
+        feedData,
       );
     case 'lemmy':
-      return await getLemmyFeed(supabaseClient, redisClient, profile, source);
+      return await getLemmyFeed(
+        supabaseClient,
+        redisClient,
+        profile,
+        source,
+        feedData,
+      );
     case 'mastodon':
       return await getMastodonFeed(
         supabaseClient,
         redisClient,
         profile,
         source,
+        feedData,
       );
     case 'medium':
-      return await getMediumFeed(supabaseClient, redisClient, profile, source);
+      return await getMediumFeed(
+        supabaseClient,
+        redisClient,
+        profile,
+        source,
+        feedData,
+      );
     case 'nitter':
-      return await getNitterFeed(supabaseClient, redisClient, profile, source);
+      return await getNitterFeed(
+        supabaseClient,
+        redisClient,
+        profile,
+        source,
+        feedData,
+      );
     case 'pinterest':
       return await getPinterestFeed(
         supabaseClient,
         redisClient,
         profile,
         source,
+        feedData,
       );
     case 'podcast':
-      return await getPodcastFeed(supabaseClient, redisClient, profile, source);
+      return await getPodcastFeed(
+        supabaseClient,
+        redisClient,
+        profile,
+        source,
+        feedData,
+      );
     case 'reddit':
-      return await getRedditFeed(supabaseClient, redisClient, profile, source);
+      return await getRedditFeed(
+        supabaseClient,
+        redisClient,
+        profile,
+        source,
+        feedData,
+      );
     case 'rss':
       try {
         if (source.options?.rss && isLemmyUrl(source.options.rss)) {
           return await getLemmyFeed(supabaseClient, redisClient, profile, {
             ...source,
             options: { lemmy: source.options.rss },
-          });
+          }, feedData);
         }
 
         if (source.options?.rss && isMediumUrl(source.options.rss)) {
           return await getMediumFeed(supabaseClient, redisClient, profile, {
             ...source,
             options: { medium: source.options.rss },
-          });
+          }, feedData);
         }
 
         if (source.options?.rss && isPinterestUrl(source.options.rss)) {
           return await getPinterestFeed(supabaseClient, redisClient, profile, {
             ...source,
             options: { pinterest: source.options.rss },
-          });
+          }, feedData);
         }
 
         if (source.options?.rss && isRedditUrl(source.options.rss)) {
           return await getTumblrFeed(supabaseClient, redisClient, profile, {
             ...source,
             options: { reddit: source.options.reddit },
-          });
+          }, feedData);
         }
 
         if (source.options?.rss && isTumblrUrl(source.options.rss)) {
           return await getTumblrFeed(supabaseClient, redisClient, profile, {
             ...source,
             options: { tumblr: source.options.rss },
-          });
+          }, feedData);
         }
 
         if (source.options?.rss && isYoutubeUrl(source.options.rss)) {
           return await getYoutubeFeed(supabaseClient, redisClient, profile, {
             ...source,
             options: { youtube: source.options.rss },
-          });
+          }, feedData);
         }
       } catch (_) {
         /**
@@ -115,20 +155,39 @@ export const getFeed = async (
          */
       }
 
-      return await getRSSFeed(supabaseClient, redisClient, profile, source);
+      return await getRSSFeed(
+        supabaseClient,
+        redisClient,
+        profile,
+        source,
+        feedData,
+      );
     case 'stackoverflow':
       return await getStackoverflowFeed(
         supabaseClient,
         redisClient,
         profile,
         source,
+        feedData,
       );
     case 'tumblr':
-      return await getTumblrFeed(supabaseClient, redisClient, profile, source);
-    // case "x":
-    //   return await getXFeed(supabaseClient, redisClient, profile, source);
+      return await getTumblrFeed(
+        supabaseClient,
+        redisClient,
+        profile,
+        source,
+        feedData,
+      );
+    // case 'x':
+    //   return await getXFeed(supabaseClient, redisClient, profile, source, data);
     case 'youtube':
-      return await getYoutubeFeed(supabaseClient, redisClient, profile, source);
+      return await getYoutubeFeed(
+        supabaseClient,
+        redisClient,
+        profile,
+        source,
+        feedData,
+      );
     default:
       throw new feedutils.FeedValidationError('Invalid source options');
   }

--- a/supabase/functions/_shared/feed/github.ts
+++ b/supabase/functions/_shared/feed/github.ts
@@ -12,6 +12,7 @@ export const getGithubFeed = async (
   _redisClient: Redis | undefined,
   profile: IProfile,
   source: ISource,
+  _feedData: string | undefined,
 ): Promise<{ source: ISource; items: IItem[] }> => {
   if (!source.options?.github || !source.options?.github.type) {
     throw new feedutils.FeedValidationError('Invalid source options');
@@ -441,13 +442,13 @@ const formatDescription = (notification: any): string | undefined => {
     case 'mention':
       return 'You were specifically @mentioned in the content.';
     case 'review_requested':
-      return 'You, or a team you\'re a member of, were requested to review a pull request.';
+      return "You, or a team you're a member of, were requested to review a pull request.";
     case 'security_alert':
       return 'GitHub discovered a security vulnerability in your repository.';
     case 'state_change':
       return 'You changed the thread state (for example, closing an issue or merging a pull request).';
     case 'subscribed':
-      return 'You\'re watching the repository.';
+      return "You're watching the repository.";
     case 'team_mention':
       return 'You were on a team that was mentioned.';
     default:

--- a/supabase/functions/_shared/feed/googlenews.ts
+++ b/supabase/functions/_shared/feed/googlenews.ts
@@ -14,6 +14,7 @@ export const getGooglenewsFeed = async (
   redisClient: Redis | undefined,
   _profile: IProfile,
   source: ISource,
+  feedData: string | undefined,
 ): Promise<{ source: ISource; items: IItem[] }> => {
   if (!source.options?.googlenews || !source.options?.googlenews?.type) {
     throw new feedutils.FeedValidationError('Invalid source options');
@@ -63,6 +64,7 @@ export const getGooglenewsFeed = async (
   const feed = await feedutils.getAndParseFeed(
     source.options.googlenews.url,
     source,
+    feedData,
   );
 
   if (!feed.title.value) {

--- a/supabase/functions/_shared/feed/googlenews_test.ts
+++ b/supabase/functions/_shared/feed/googlenews_test.ts
@@ -113,6 +113,7 @@ Deno.test('getGooglenewsFeed - Url', async () => {
           },
         },
       },
+      undefined,
     );
     feedutils.assertEqualsSource(source, {
       'id': 'googlenews-myuser-mycolumn-8c1368ef1bc9e52356bffba3ce60cd48',
@@ -204,6 +205,7 @@ Deno.test('getGooglenewsFeed - Search', async () => {
           },
         },
       },
+      undefined,
     );
     feedutils.assertEqualsSource(source, {
       'id': 'googlenews-myuser-mycolumn-5ef472fe226393772d05c92261df68e1',

--- a/supabase/functions/_shared/feed/lemmy.ts
+++ b/supabase/functions/_shared/feed/lemmy.ts
@@ -119,6 +119,7 @@ export const getLemmyFeed = async (
   _redisClient: Redis | undefined,
   _profile: IProfile,
   source: ISource,
+  feedData: string | undefined,
 ): Promise<{ source: ISource; items: IItem[] }> => {
   if (!source.options?.lemmy) {
     throw new feedutils.FeedValidationError('Invalid source options');
@@ -147,7 +148,11 @@ export const getLemmyFeed = async (
    * Get the RSS for the provided `lemmy` url and parse it. If a feed doesn't
    * contains a title we return an error.
    */
-  const feed = await feedutils.getAndParseFeed(source.options.lemmy, source);
+  const feed = await feedutils.getAndParseFeed(
+    source.options.lemmy,
+    source,
+    feedData,
+  );
 
   if (!feed.title.value) {
     throw new Error('Invalid feed');

--- a/supabase/functions/_shared/feed/lemmy_test.ts
+++ b/supabase/functions/_shared/feed/lemmy_test.ts
@@ -223,6 +223,7 @@ Deno.test('getLemmyFeed - User', async () => {
       undefined,
       mockProfile,
       { ...mockSource, options: { lemmy: 'https://lemmy.world/u/lwCET' } },
+      undefined,
     );
     feedutils.assertEqualsSource(source, {
       'id': 'lemmy-myuser-mycolumn-9b51f0368938451bfbd740fad833b7a4',
@@ -297,6 +298,7 @@ Deno.test('getLemmyFeed - Community', async () => {
       undefined,
       mockProfile,
       { ...mockSource, options: { lemmy: 'https://lemmy.world/c/lemmyworld' } },
+      undefined,
     );
     feedutils.assertEqualsSource(source, {
       'id': 'lemmy-myuser-mycolumn-8024684791f06e280f6fbd7217099f42',
@@ -373,6 +375,7 @@ Deno.test('getLemmyFeed - Community - IIC', async () => {
         ...mockSource,
         options: { lemmy: 'https://lemmy.world/feeds/c/idiotsincars.xml' },
       },
+      undefined,
     );
     feedutils.assertEqualsSource(source, {
       'id': 'lemmy-myuser-mycolumn-e5cb4d4594ce7d19987fd42ca1dd837f',

--- a/supabase/functions/_shared/feed/mastodon.ts
+++ b/supabase/functions/_shared/feed/mastodon.ts
@@ -14,6 +14,7 @@ export const getMastodonFeed = async (
   _redisClient: Redis | undefined,
   _profile: IProfile,
   source: ISource,
+  feedData: string | undefined,
 ): Promise<{ source: ISource; items: IItem[] }> => {
   if (!source.options?.mastodon || source.options.mastodon.length === 0) {
     throw new feedutils.FeedValidationError('Invalid source options');
@@ -40,7 +41,11 @@ export const getMastodonFeed = async (
   /**
    * Get the RSS for the provided Mastodon username, hashtag or url.
    */
-  const feed = await feedutils.getAndParseFeed(source.options.mastodon, source);
+  const feed = await feedutils.getAndParseFeed(
+    source.options.mastodon,
+    source,
+    feedData,
+  );
 
   if (!feed.title.value) {
     throw new Error('Invalid feed');

--- a/supabase/functions/_shared/feed/mastodon_test.ts
+++ b/supabase/functions/_shared/feed/mastodon_test.ts
@@ -142,6 +142,7 @@ Deno.test('getMastodonFeed - Tag', async () => {
         ...mockSource,
         options: { mastodon: 'https://hachyderm.io/tags/Kubernetes' },
       },
+      undefined,
     );
     feedutils.assertEqualsSource(source, {
       'id': 'mastodon-myuser-mycolumn-91151e10882e4fff432ff509b8c6b027',
@@ -248,6 +249,7 @@ Deno.test('getMastodonFeed - User', async () => {
       undefined,
       mockProfile,
       { ...mockSource, options: { mastodon: '@ricoberger@hachyderm.io' } },
+      undefined,
     );
     feedutils.assertEqualsSource(source, {
       'id': 'mastodon-myuser-mycolumn-5673bdae9d06a0744e93d647fe5cef2e',

--- a/supabase/functions/_shared/feed/medium.ts
+++ b/supabase/functions/_shared/feed/medium.ts
@@ -68,6 +68,7 @@ export const getMediumFeed = async (
   _redisClient: Redis | undefined,
   _profile: IProfile,
   source: ISource,
+  feedData: string | undefined,
 ): Promise<{ source: ISource; items: IItem[] }> => {
   const parsedMediumOption = parseMediumOption(source.options?.medium);
 
@@ -75,7 +76,11 @@ export const getMediumFeed = async (
    * Get the RSS for the provided `medium` url and parse it. If a feed doesn't
    * contains a title we return an error.
    */
-  const feed = await feedutils.getAndParseFeed(parsedMediumOption, source);
+  const feed = await feedutils.getAndParseFeed(
+    parsedMediumOption,
+    source,
+    feedData,
+  );
 
   if (!feed.title.value) {
     throw new Error('Invalid feed');

--- a/supabase/functions/_shared/feed/medium_test.ts
+++ b/supabase/functions/_shared/feed/medium_test.ts
@@ -202,6 +202,7 @@ Deno.test('getMediumFeed - Tag', async () => {
       undefined,
       mockProfile,
       { ...mockSource, options: { medium: '#kubernetes' } },
+      undefined,
     );
     feedutils.assertEqualsSource(source, {
       id: 'medium-myuser-mycolumn-40f28b0a56743a117745ac7dfd785111',
@@ -295,6 +296,7 @@ Deno.test('getMediumFeed - User', async () => {
       undefined,
       mockProfile,
       { ...mockSource, options: { medium: '@YuriShkuro' } },
+      undefined,
     );
     feedutils.assertEqualsSource(source, {
       id: 'medium-myuser-mycolumn-77107c9209365c6c6c601a9f018a05f4',

--- a/supabase/functions/_shared/feed/nitter.ts
+++ b/supabase/functions/_shared/feed/nitter.ts
@@ -18,6 +18,7 @@ export const getNitterFeed = async (
   _redisClient: Redis | undefined,
   _profile: IProfile,
   source: ISource,
+  feedData: string | undefined,
 ): Promise<{ source: ISource; items: IItem[] }> => {
   if (!source.options?.nitter || source.options.nitter.length === 0) {
     throw new feedutils.FeedValidationError('Invalid source options');
@@ -32,6 +33,7 @@ export const getNitterFeed = async (
   const feed = await feedutils.getAndParseFeed(
     nitterOptions.feedUrl,
     source,
+    feedData,
     nitterOptions.isCustomInstance ? undefined : {
       headers: {
         'Authorization': `Basic ${FEEDDECK_SOURCE_NITTER_BASIC_AUTH}`,

--- a/supabase/functions/_shared/feed/nitter_test.ts
+++ b/supabase/functions/_shared/feed/nitter_test.ts
@@ -225,6 +225,7 @@ Deno.test('getNitterFeed - Tag', async () => {
           nitter: 'https://nitter.net/search/rss?f=tweets&q=kubernetes',
         },
       },
+      undefined,
     );
     feedutils.assertEqualsSource(source, {
       'id': 'nitter-myuser-mycolumn-14a83e961dc175e20f36e70373cbae6e',
@@ -344,6 +345,7 @@ Deno.test('getNitterFeed - User', async () => {
         ...mockSource,
         options: { nitter: 'https://nitter.net/rico_berger/rss' },
       },
+      undefined,
     );
     feedutils.assertEqualsSource(source, {
       'id': 'nitter-myuser-mycolumn-2f69b5c79645e7868dbefdee825bbb90',

--- a/supabase/functions/_shared/feed/pinterest.ts
+++ b/supabase/functions/_shared/feed/pinterest.ts
@@ -114,6 +114,7 @@ export const getPinterestFeed = async (
   _redisClient: Redis | undefined,
   _profile: IProfile,
   source: ISource,
+  feedData: string | undefined,
 ): Promise<{ source: ISource; items: IItem[] }> => {
   const parsedPinterestOption = parsePinterestOption(source.options?.pinterest);
 
@@ -121,7 +122,11 @@ export const getPinterestFeed = async (
    * Get the RSS for the provided `pinterest` url and parse it. If a feed
    * doesn't contains a title we return an error.
    */
-  const feed = await feedutils.getAndParseFeed(parsedPinterestOption, source);
+  const feed = await feedutils.getAndParseFeed(
+    parsedPinterestOption,
+    source,
+    feedData,
+  );
 
   if (!feed.title.value) {
     throw new Error('Invalid feed');

--- a/supabase/functions/_shared/feed/pinterest_test.ts
+++ b/supabase/functions/_shared/feed/pinterest_test.ts
@@ -114,6 +114,7 @@ Deno.test('getPinterestFeed - User', async () => {
         ...mockSource,
         options: { pinterest: 'https://www.pinterest.de/pinterestde' },
       },
+      undefined,
     );
     feedutils.assertEqualsSource(source, {
       'id': 'pinterest-myuser-mycolumn-18a73e1c3eb363440dbd64cfa9dfd1ab',

--- a/supabase/functions/_shared/feed/podcast.ts
+++ b/supabase/functions/_shared/feed/podcast.ts
@@ -14,6 +14,7 @@ export const getPodcastFeed = async (
   _redisClient: Redis | undefined,
   _profile: IProfile,
   source: ISource,
+  feedData: string | undefined,
 ): Promise<{ source: ISource; items: IItem[] }> => {
   if (!source.options?.podcast) {
     throw new feedutils.FeedValidationError('Invalid source options');
@@ -35,7 +36,11 @@ export const getPodcastFeed = async (
    * Get the RSS for the provided `podcast` url and parse it. If a feed doesn't
    * contains a title we return an error.
    */
-  const feed = await feedutils.getAndParseFeed(source.options.podcast, source);
+  const feed = await feedutils.getAndParseFeed(
+    source.options.podcast,
+    source,
+    feedData,
+  );
 
   if (!feed.title.value) {
     throw new Error('Invalid feed');

--- a/supabase/functions/_shared/feed/podcast_test.ts
+++ b/supabase/functions/_shared/feed/podcast_test.ts
@@ -133,6 +133,7 @@ Deno.test('getPodcastFeed - RSS', async () => {
         ...mockSource,
         options: { podcast: 'https://kubernetespodcast.com/feeds/audio.xml' },
       },
+      undefined,
     );
     assertEqualsSource(source, {
       'id': 'podcast-myuser-mycolumn-9d151d96e51e542b848a39982f685eef',
@@ -412,6 +413,7 @@ Deno.test('getPodcastFeed - Apple', async () => {
             'https://podcasts.apple.com/de/podcast/go-time-golang-software-engineering/id1120964487',
         },
       },
+      undefined,
     );
     assertEqualsSource(source, {
       'id': 'podcast-myuser-mycolumn-aad37b7b4ebb1f79286d7b9e24bb4163',

--- a/supabase/functions/_shared/feed/reddit.ts
+++ b/supabase/functions/_shared/feed/reddit.ts
@@ -23,6 +23,7 @@ export const getRedditFeed = async (
   _redisClient: Redis | undefined,
   _profile: IProfile,
   source: ISource,
+  feedData: string | undefined,
 ): Promise<{ source: ISource; items: IItem[] }> => {
   if (!source.options?.reddit) {
     throw new feedutils.FeedValidationError('Invalid source options');
@@ -44,7 +45,11 @@ export const getRedditFeed = async (
    * Get the RSS for the provided `youtube` url and parse it. If a feed doesn't
    * contains an item we return an error.
    */
-  const feed = await feedutils.getAndParseFeed(source.options.reddit, source);
+  const feed = await feedutils.getAndParseFeed(
+    source.options.reddit,
+    source,
+    feedData,
+  );
 
   if (!feed.title.value) {
     throw new Error('Invalid feed');

--- a/supabase/functions/_shared/feed/reddit_test.ts
+++ b/supabase/functions/_shared/feed/reddit_test.ts
@@ -133,6 +133,7 @@ Deno.test('getRedditFeed', async () => {
         ...mockSource,
         options: { reddit: '/r/kubernetes' },
       },
+      undefined,
     );
     feedutils.assertEqualsSource(source, {
       'id': 'reddit-myuser-mycolumn-87e62a33042b3fdf4eac36ae57d55fc8',

--- a/supabase/functions/_shared/feed/rss.ts
+++ b/supabase/functions/_shared/feed/rss.ts
@@ -16,6 +16,7 @@ export const getRSSFeed = async (
   _redisClient: Redis | undefined,
   _profile: IProfile,
   source: ISource,
+  feedData: string | undefined,
 ): Promise<{ source: ISource; items: IItem[] }> => {
   /**
    * To get a RSS feed the `source` must have a `rss` option. This option is
@@ -26,7 +27,7 @@ export const getRSSFeed = async (
     throw new feedutils.FeedValidationError('Invalid source options');
   }
 
-  let feed = await getFeed(source);
+  let feed = await getFeed(source, feedData);
   if (!feed) {
     utils.log(
       'debug',
@@ -161,9 +162,16 @@ export const getRSSFeed = async (
  * the feed or undefined if the request failed or the returned response could
  * not be parsed as a feed.
  */
-const getFeed = async (source: ISource): Promise<Feed | undefined> => {
+const getFeed = async (
+  source: ISource,
+  feedData: string | undefined,
+): Promise<Feed | undefined> => {
   try {
-    const feed = await feedutils.getAndParseFeed(source.options!.rss!, source);
+    const feed = await feedutils.getAndParseFeed(
+      source.options!.rss!,
+      source,
+      feedData,
+    );
     return feed;
   } catch (_) {
     return undefined;
@@ -208,7 +216,7 @@ const getFeedFromWebsite = async (
     }
     source.options!.rss = new URL(rssLink, source.options!.rss!).href;
 
-    return getFeed(source);
+    return getFeed(source, undefined);
   } catch (_) {
     return undefined;
   }

--- a/supabase/functions/_shared/feed/rss_test.ts
+++ b/supabase/functions/_shared/feed/rss_test.ts
@@ -205,6 +205,7 @@ Deno.test('getRSSFeed - Tagesschau Website', async () => {
           rss: 'https://www.tagesschau.de',
         },
       },
+      undefined,
     );
     assertEqualsSource(source, {
       'id': 'rss-myuser-mycolumn-790bbd13d8bff02d80672419ea0709b5',
@@ -407,6 +408,7 @@ Deno.test('getRSSFeed - Tagesschau Atom', async () => {
           rss: 'https://www.tagesschau.de/index~atom.xml',
         },
       },
+      undefined,
     );
     assertEqualsSource(source, {
       'id': 'rss-myuser-mycolumn-8465a4b4e81845fd534f45a3ef63ae7f',
@@ -602,6 +604,7 @@ Deno.test('getRSSFeed - Tagesschau RDF', async () => {
           rss: 'https://www.tagesschau.de/index~rdf.xml',
         },
       },
+      undefined,
     );
     assertEqualsSource(source, {
       'id': 'rss-myuser-mycolumn-315eca5c9ed1af9968989241a5b7de09',
@@ -768,6 +771,7 @@ Deno.test('getRSSFeed - NYT', async () => {
           rss: 'https://rss.nytimes.com/services/xml/rss/nyt/World.xml',
         },
       },
+      undefined,
     );
     assertEqualsSource(source, {
       'id': 'rss-myuser-mycolumn-befdaecfac50335eaa1a93512d673fb6',
@@ -961,6 +965,7 @@ Deno.test('getRSSFeed - CNN', async () => {
           rss: 'http://rss.cnn.com/rss/cnn_latest.rss',
         },
       },
+      undefined,
     );
     assertEqualsSource(source, {
       'id': 'rss-myuser-mycolumn-27c792d08caef396bf1e3ce488f6b4ea',
@@ -1127,6 +1132,7 @@ Deno.test('getRSSFeed - NTV', async () => {
           rss: 'https://www.n-tv.de/rss',
         },
       },
+      undefined,
     );
     assertEqualsSource(source, {
       'id': 'rss-myuser-mycolumn-390a57640c2613653000729c6fef53ae',
@@ -1283,6 +1289,7 @@ Deno.test('getRSSFeed - FP', async () => {
           rss: 'https://www.freiepresse.de/rss/rss_chemnitz.php',
         },
       },
+      undefined,
     );
     assertEqualsSource(source, {
       'id': 'rss-myuser-mycolumn-3d20715877c48f9b58c13809c5abc600',
@@ -1470,6 +1477,7 @@ Deno.test('getRSSFeed - HV', async () => {
           rss: 'https://www.hippovideo.io/blog/feed/',
         },
       },
+      undefined,
     );
     assertEqualsSource(source, {
       'id': 'rss-myuser-mycolumn-f09335225050a5529306575010bf8aa4',

--- a/supabase/functions/_shared/feed/stackoverflow.ts
+++ b/supabase/functions/_shared/feed/stackoverflow.ts
@@ -14,6 +14,7 @@ export const getStackoverflowFeed = async (
   _redisClient: Redis | undefined,
   _profile: IProfile,
   source: ISource,
+  feedData: string | undefined,
 ): Promise<{ source: ISource; items: IItem[] }> => {
   if (!source.options?.stackoverflow || !source.options?.stackoverflow?.type) {
     throw new feedutils.FeedValidationError('Invalid source options');
@@ -35,6 +36,7 @@ export const getStackoverflowFeed = async (
   const feed = await feedutils.getAndParseFeed(
     source.options.stackoverflow.url,
     source,
+    feedData,
   );
 
   if (!feed.title.value) {

--- a/supabase/functions/_shared/feed/stackoverflow_test.ts
+++ b/supabase/functions/_shared/feed/stackoverflow_test.ts
@@ -138,6 +138,7 @@ Deno.test('getStackoverflowFeed', async () => {
           stackoverflow: { type: 'tag', tag: 'kubernetes', sort: 'newest' },
         },
       },
+      undefined,
     );
     feedutils.assertEqualsSource(source, {
       'id': 'stackoverflow-myuser-mycolumn-b33aefc859cbc9c75f22dc8de83b59e7',

--- a/supabase/functions/_shared/feed/tumblr.ts
+++ b/supabase/functions/_shared/feed/tumblr.ts
@@ -23,6 +23,7 @@ export const getTumblrFeed = async (
   _redisClient: Redis | undefined,
   _profile: IProfile,
   source: ISource,
+  feedData: string | undefined,
 ): Promise<{ source: ISource; items: IItem[] }> => {
   if (!source.options?.tumblr) {
     throw new feedutils.FeedValidationError('Invalid source options');
@@ -48,7 +49,11 @@ export const getTumblrFeed = async (
    * Get the RSS for the provided `tumblr` url and parse it. If a feed doesn't
    * contains a title we return an error.
    */
-  const feed = await feedutils.getAndParseFeed(source.options.tumblr, source);
+  const feed = await feedutils.getAndParseFeed(
+    source.options.tumblr,
+    source,
+    feedData,
+  );
 
   if (!feed.title.value) {
     throw new Error('Invalid feed');

--- a/supabase/functions/_shared/feed/tumblr_test.ts
+++ b/supabase/functions/_shared/feed/tumblr_test.ts
@@ -98,6 +98,7 @@ Deno.test('getTumblrFeed', async () => {
         ...mockSource,
         options: { tumblr: 'https://www.tumblr.com/todayontumblr' },
       },
+      undefined,
     );
     feedutils.assertEqualsSource(source, {
       'id': 'tumblr-myuser-mycolumn-8ce77e730a91955cd991349d0d6bfb6c',

--- a/supabase/functions/_shared/feed/x.ts
+++ b/supabase/functions/_shared/feed/x.ts
@@ -13,6 +13,7 @@ export const getXFeed = async (
   _redisClient: Redis | undefined,
   _profile: IProfile,
   source: ISource,
+  _feedData: string | undefined,
 ): Promise<{ source: ISource; items: IItem[] }> => {
   if (!source.options?.x || source.options.x.length === 0) {
     throw new feedutils.FeedValidationError('Invalid source options');

--- a/supabase/functions/_shared/feed/youtube.ts
+++ b/supabase/functions/_shared/feed/youtube.ts
@@ -26,6 +26,7 @@ export const getYoutubeFeed = async (
   _redisClient: Redis | undefined,
   _profile: IProfile,
   source: ISource,
+  feedData: string | undefined,
 ): Promise<{ source: ISource; items: IItem[] }> => {
   if (!source.options?.youtube) {
     throw new feedutils.FeedValidationError('Invalid source options');
@@ -76,6 +77,7 @@ export const getYoutubeFeed = async (
   const feed = await feedutils.getAndParseFeed(
     source.options.youtube,
     source,
+    feedData,
   );
 
   if (!feed.title.value) {

--- a/supabase/functions/_shared/feed/youtube_test.ts
+++ b/supabase/functions/_shared/feed/youtube_test.ts
@@ -256,6 +256,7 @@ Deno.test('getYoutubeFeed', async () => {
           youtube: 'https://youtube.com/@tagesschau?si=24jF6sxXvaU7Jv7D',
         },
       },
+      undefined,
     );
     assertEqualsSource(source, {
       'id': 'youtube-myuser-mycolumn-66638d79d1f4c862ef3a54be04469f22',

--- a/supabase/functions/generate-magic-link-v1/index.ts
+++ b/supabase/functions/generate-magic-link-v1/index.ts
@@ -9,10 +9,8 @@ import {
 } from '../_shared/utils/constants.ts';
 
 /**
- * The `add-source-v1` edge function is used to add a new source and it's
- * corresponding items to the database. It expects a POST request with the
- * column id, source type and options. The function will return the source
- * object as it was added to the database.
+ * The `generate-magic-link-v1` edge function is used to generate a magic link
+ * for the currently signed in user.
  */
 Deno.serve(async (req) => {
   /**


### PR DESCRIPTION
It is now possible to add and update sources via client side scraping. For that a new edge function `add-or-update-source-v1` was added and the old `add-source-v1` function was deprecated.

The new function accepts a new `feedData` field, which can contain the feed for a source. If the field is provided we will not try to get the feed for a source within our edge function and instead use the provided data.

Currently this function is only used to add a Reddit source. Later we plan to extend it for other sources and want to use it to update source via the app, when the source provider makes heavy use of rate limiting.

<!--
  Keep PR title verbose enough and add prefix telling about what source it touches e.g "[rss] Add feature xyz" or if the
  the PR is not realated to a source use "[core]", e.g. "[core] Fix xyz".

  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
