### PR TITLE
[core] Add Missing `SafeArea` Widget

### DIFF
--- a/app/lib/widgets/settings/accounts/settings_accounts_github.dart
+++ b/app/lib/widgets/settings/accounts/settings_accounts_github.dart
@@ -232,78 +232,80 @@ class _SettingsAccountsGithubAddState extends State<SettingsAccountsGithubAdd> {
           ),
         ],
       ),
-      body: Column(
-        children: [
-          Expanded(
-            child: Padding(
-              padding: const EdgeInsets.all(Constants.spacingMiddle),
-              child: SingleChildScrollView(
-                child: Form(
-                  key: _formKey,
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      MarkdownBody(
-                        selectable: true,
-                        data: _helpText,
-                        onTapLink: (text, href, title) {
-                          try {
-                            if (href != null) {
-                              openUrl(href);
-                            }
-                          } catch (_) {}
-                        },
-                      ),
-                      const SizedBox(
-                        height: Constants.spacingMiddle,
-                      ),
-                      TextFormField(
-                        controller: _tokenController,
-                        keyboardType: TextInputType.text,
-                        autocorrect: false,
-                        enableSuggestions: true,
-                        maxLines: 1,
-                        decoration: const InputDecoration(
-                          border: OutlineInputBorder(),
-                          labelText: 'Token',
+      body: SafeArea(
+        child: Column(
+          children: [
+            Expanded(
+              child: Padding(
+                padding: const EdgeInsets.all(Constants.spacingMiddle),
+                child: SingleChildScrollView(
+                  child: Form(
+                    key: _formKey,
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        MarkdownBody(
+                          selectable: true,
+                          data: _helpText,
+                          onTapLink: (text, href, title) {
+                            try {
+                              if (href != null) {
+                                openUrl(href);
+                              }
+                            } catch (_) {}
+                          },
                         ),
-                        validator: (value) => _validateToken(value),
-                        onFieldSubmitted: (value) => _addAccount(),
-                      ),
-                    ],
+                        const SizedBox(
+                          height: Constants.spacingMiddle,
+                        ),
+                        TextFormField(
+                          controller: _tokenController,
+                          keyboardType: TextInputType.text,
+                          autocorrect: false,
+                          enableSuggestions: true,
+                          maxLines: 1,
+                          decoration: const InputDecoration(
+                            border: OutlineInputBorder(),
+                            labelText: 'Token',
+                          ),
+                          validator: (value) => _validateToken(value),
+                          onFieldSubmitted: (value) => _addAccount(),
+                        ),
+                      ],
+                    ),
                   ),
                 ),
               ),
             ),
-          ),
-          const SizedBox(
-            height: Constants.spacingSmall,
-          ),
-          const Divider(
-            color: Constants.dividerColor,
-            height: 1,
-            thickness: 1,
-          ),
-          _buildError(),
-          Padding(
-            padding: const EdgeInsets.all(Constants.spacingMiddle),
-            child: ElevatedButton.icon(
-              style: ElevatedButton.styleFrom(
-                maximumSize: const Size.fromHeight(
-                  Constants.elevatedButtonSize,
-                ),
-                minimumSize: const Size.fromHeight(
-                  Constants.elevatedButtonSize,
-                ),
-              ),
-              label: const Text('Add Account'),
-              onPressed: _isLoading ? null : _addAccount,
-              icon: _isLoading
-                  ? const ElevatedButtonProgressIndicator()
-                  : const Icon(Icons.add),
+            const SizedBox(
+              height: Constants.spacingSmall,
             ),
-          ),
-        ],
+            const Divider(
+              color: Constants.dividerColor,
+              height: 1,
+              thickness: 1,
+            ),
+            _buildError(),
+            Padding(
+              padding: const EdgeInsets.all(Constants.spacingMiddle),
+              child: ElevatedButton.icon(
+                style: ElevatedButton.styleFrom(
+                  maximumSize: const Size.fromHeight(
+                    Constants.elevatedButtonSize,
+                  ),
+                  minimumSize: const Size.fromHeight(
+                    Constants.elevatedButtonSize,
+                  ),
+                ),
+                label: const Text('Add Account'),
+                onPressed: _isLoading ? null : _addAccount,
+                icon: _isLoading
+                    ? const ElevatedButtonProgressIndicator()
+                    : const Icon(Icons.add),
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/app/lib/widgets/settings/premium/settings_premium_inapp.dart
+++ b/app/lib/widgets/settings/premium/settings_premium_inapp.dart
@@ -166,28 +166,29 @@ class _SettingsPremiumInAppState extends State<SettingsPremiumInApp> {
           ),
         ],
       ),
-      body: FutureBuilder(
-        future: _futureFetchOfferings,
-        builder: (
-          BuildContext context,
-          AsyncSnapshot<Offering?> snapshot,
-        ) {
-          return Column(
-            children: [
-              Expanded(
-                child: Padding(
-                  padding: const EdgeInsets.all(Constants.spacingMiddle),
-                  child: SingleChildScrollView(
-                    child: snapshot.connectionState == ConnectionState.none ||
-                            snapshot.connectionState ==
-                                ConnectionState.waiting ||
-                            snapshot.hasError ||
-                            snapshot.data == null ||
-                            snapshot.data?.monthly == null
-                        ? const Text('Loading ...')
-                        : MarkdownBody(
-                            selectable: true,
-                            data: '''
+      body: SafeArea(
+        child: FutureBuilder(
+          future: _futureFetchOfferings,
+          builder: (
+            BuildContext context,
+            AsyncSnapshot<Offering?> snapshot,
+          ) {
+            return Column(
+              children: [
+                Expanded(
+                  child: Padding(
+                    padding: const EdgeInsets.all(Constants.spacingMiddle),
+                    child: SingleChildScrollView(
+                      child: snapshot.connectionState == ConnectionState.none ||
+                              snapshot.connectionState ==
+                                  ConnectionState.waiting ||
+                              snapshot.hasError ||
+                              snapshot.data == null ||
+                              snapshot.data?.monthly == null
+                          ? const Text('Loading ...')
+                          : MarkdownBody(
+                              selectable: true,
+                              data: '''
 You are currently using the free version of FeedDeck, which allows you to add up
 to 10 sources for the first 7 days. After that trial period your sources will
 not be updated anymore.
@@ -197,57 +198,61 @@ upgrade to a premium account. The premium account costs
 ${snapshot.data?.monthly?.storeProduct.priceString} per month and can be
 canceled at any time.
 ''',
-                          ),
-                  ),
-                ),
-              ),
-              const SizedBox(
-                height: Constants.spacingSmall,
-              ),
-              const Divider(
-                color: Constants.dividerColor,
-                height: 1,
-                thickness: 1,
-              ),
-              Padding(
-                padding: const EdgeInsets.all(Constants.spacingMiddle),
-                child: ElevatedButton.icon(
-                  style: ElevatedButton.styleFrom(
-                    backgroundColor: Constants.primary,
-                    foregroundColor: Constants.onPrimary,
-                    maximumSize: const Size.fromHeight(
-                      Constants.elevatedButtonSize,
-                    ),
-                    minimumSize: const Size.fromHeight(
-                      Constants.elevatedButtonSize,
+                            ),
                     ),
                   ),
-                  label: Text(
-                    snapshot.data?.monthly?.storeProduct.priceString != null
-                        ? 'Subscribe to FeedDeck Premium for ${snapshot.data?.monthly?.storeProduct.priceString}'
-                        : 'Subscribe to FeedDeck Premium',
-                  ),
-                  onPressed: snapshot.connectionState == ConnectionState.none ||
-                          snapshot.connectionState == ConnectionState.waiting ||
-                          snapshot.hasError ||
-                          snapshot.data == null ||
-                          snapshot.data?.monthly == null ||
-                          _isLoading
-                      ? null
-                      : () => _purchase(snapshot.data!.monthly!),
-                  icon: snapshot.connectionState == ConnectionState.none ||
-                          snapshot.connectionState == ConnectionState.waiting ||
-                          snapshot.hasError ||
-                          snapshot.data == null ||
-                          snapshot.data?.monthly == null ||
-                          _isLoading
-                      ? const ElevatedButtonProgressIndicator()
-                      : const Icon(FDIcons.feeddeck),
                 ),
-              ),
-            ],
-          );
-        },
+                const SizedBox(
+                  height: Constants.spacingSmall,
+                ),
+                const Divider(
+                  color: Constants.dividerColor,
+                  height: 1,
+                  thickness: 1,
+                ),
+                Padding(
+                  padding: const EdgeInsets.all(Constants.spacingMiddle),
+                  child: ElevatedButton.icon(
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: Constants.primary,
+                      foregroundColor: Constants.onPrimary,
+                      maximumSize: const Size.fromHeight(
+                        Constants.elevatedButtonSize,
+                      ),
+                      minimumSize: const Size.fromHeight(
+                        Constants.elevatedButtonSize,
+                      ),
+                    ),
+                    label: Text(
+                      snapshot.data?.monthly?.storeProduct.priceString != null
+                          ? 'Subscribe to FeedDeck Premium for ${snapshot.data?.monthly?.storeProduct.priceString}'
+                          : 'Subscribe to FeedDeck Premium',
+                    ),
+                    onPressed:
+                        snapshot.connectionState == ConnectionState.none ||
+                                snapshot.connectionState ==
+                                    ConnectionState.waiting ||
+                                snapshot.hasError ||
+                                snapshot.data == null ||
+                                snapshot.data?.monthly == null ||
+                                _isLoading
+                            ? null
+                            : () => _purchase(snapshot.data!.monthly!),
+                    icon: snapshot.connectionState == ConnectionState.none ||
+                            snapshot.connectionState ==
+                                ConnectionState.waiting ||
+                            snapshot.hasError ||
+                            snapshot.data == null ||
+                            snapshot.data?.monthly == null ||
+                            _isLoading
+                        ? const ElevatedButtonProgressIndicator()
+                        : const Icon(FDIcons.feeddeck),
+                  ),
+                ),
+              ],
+            );
+          },
+        ),
       ),
     );
   }

--- a/app/lib/widgets/settings/premium/settings_premium_stripe.dart
+++ b/app/lib/widgets/settings/premium/settings_premium_stripe.dart
@@ -87,62 +87,67 @@ class _SettingsPremiumStripeState extends State<SettingsPremiumStripe> {
           ),
         ],
       ),
-      body: FutureBuilder(
-        future: _futureFetchCheckoutSessionLink,
-        builder: (
-          BuildContext context,
-          AsyncSnapshot<String> snapshot,
-        ) {
-          return Column(
-            children: [
-              const Expanded(
-                child: Padding(
-                  padding: EdgeInsets.all(Constants.spacingMiddle),
-                  child: SingleChildScrollView(
-                    child: MarkdownBody(
-                      selectable: true,
-                      data: _settingsPremiumStripeText,
+      body: SafeArea(
+        child: FutureBuilder(
+          future: _futureFetchCheckoutSessionLink,
+          builder: (
+            BuildContext context,
+            AsyncSnapshot<String> snapshot,
+          ) {
+            return Column(
+              children: [
+                const Expanded(
+                  child: Padding(
+                    padding: EdgeInsets.all(Constants.spacingMiddle),
+                    child: SingleChildScrollView(
+                      child: MarkdownBody(
+                        selectable: true,
+                        data: _settingsPremiumStripeText,
+                      ),
                     ),
                   ),
                 ),
-              ),
-              const SizedBox(
-                height: Constants.spacingSmall,
-              ),
-              const Divider(
-                color: Constants.dividerColor,
-                height: 1,
-                thickness: 1,
-              ),
-              Padding(
-                padding: const EdgeInsets.all(Constants.spacingMiddle),
-                child: ElevatedButton.icon(
-                  style: ElevatedButton.styleFrom(
-                    backgroundColor: Constants.primary,
-                    foregroundColor: Constants.onPrimary,
-                    maximumSize: const Size.fromHeight(
-                      Constants.elevatedButtonSize,
-                    ),
-                    minimumSize: const Size.fromHeight(
-                      Constants.elevatedButtonSize,
-                    ),
-                  ),
-                  label: const Text('Subscribe to FeedDeck Premium'),
-                  onPressed: snapshot.connectionState == ConnectionState.none ||
-                          snapshot.connectionState == ConnectionState.waiting ||
-                          snapshot.hasError
-                      ? null
-                      : () => _openUrl(snapshot.data),
-                  icon: snapshot.connectionState == ConnectionState.none ||
-                          snapshot.connectionState == ConnectionState.waiting ||
-                          snapshot.hasError
-                      ? const ElevatedButtonProgressIndicator()
-                      : const Icon(FDIcons.feeddeck),
+                const SizedBox(
+                  height: Constants.spacingSmall,
                 ),
-              ),
-            ],
-          );
-        },
+                const Divider(
+                  color: Constants.dividerColor,
+                  height: 1,
+                  thickness: 1,
+                ),
+                Padding(
+                  padding: const EdgeInsets.all(Constants.spacingMiddle),
+                  child: ElevatedButton.icon(
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: Constants.primary,
+                      foregroundColor: Constants.onPrimary,
+                      maximumSize: const Size.fromHeight(
+                        Constants.elevatedButtonSize,
+                      ),
+                      minimumSize: const Size.fromHeight(
+                        Constants.elevatedButtonSize,
+                      ),
+                    ),
+                    label: const Text('Subscribe to FeedDeck Premium'),
+                    onPressed:
+                        snapshot.connectionState == ConnectionState.none ||
+                                snapshot.connectionState ==
+                                    ConnectionState.waiting ||
+                                snapshot.hasError
+                            ? null
+                            : () => _openUrl(snapshot.data),
+                    icon: snapshot.connectionState == ConnectionState.none ||
+                            snapshot.connectionState ==
+                                ConnectionState.waiting ||
+                            snapshot.hasError
+                        ? const ElevatedButtonProgressIndicator()
+                        : const Icon(FDIcons.feeddeck),
+                  ),
+                ),
+              ],
+            );
+          },
+        ),
       ),
     );
   }

--- a/app/lib/widgets/settings/profile/settings_profile_customer_portal.dart
+++ b/app/lib/widgets/settings/profile/settings_profile_customer_portal.dart
@@ -180,60 +180,65 @@ class _SettingsProfileCustomerPortalModalState
           ),
         ],
       ),
-      body: FutureBuilder(
-        future: _futureFetchCustomerPortalLink,
-        builder: (
-          BuildContext context,
-          AsyncSnapshot<String> snapshot,
-        ) {
-          return Column(
-            children: [
-              const Expanded(
-                child: Padding(
-                  padding: EdgeInsets.all(Constants.spacingMiddle),
-                  child: SingleChildScrollView(
-                    child: MarkdownBody(
-                      selectable: true,
-                      data: _settingsProfileCustomerPortalText,
+      body: SafeArea(
+        child: FutureBuilder(
+          future: _futureFetchCustomerPortalLink,
+          builder: (
+            BuildContext context,
+            AsyncSnapshot<String> snapshot,
+          ) {
+            return Column(
+              children: [
+                const Expanded(
+                  child: Padding(
+                    padding: EdgeInsets.all(Constants.spacingMiddle),
+                    child: SingleChildScrollView(
+                      child: MarkdownBody(
+                        selectable: true,
+                        data: _settingsProfileCustomerPortalText,
+                      ),
                     ),
                   ),
                 ),
-              ),
-              const SizedBox(
-                height: Constants.spacingSmall,
-              ),
-              const Divider(
-                color: Constants.dividerColor,
-                height: 1,
-                thickness: 1,
-              ),
-              Padding(
-                padding: const EdgeInsets.all(Constants.spacingMiddle),
-                child: ElevatedButton.icon(
-                  style: ElevatedButton.styleFrom(
-                    maximumSize: const Size.fromHeight(
-                      Constants.elevatedButtonSize,
-                    ),
-                    minimumSize: const Size.fromHeight(
-                      Constants.elevatedButtonSize,
-                    ),
-                  ),
-                  label: const Text('Open Customer Portal'),
-                  onPressed: snapshot.connectionState == ConnectionState.none ||
-                          snapshot.connectionState == ConnectionState.waiting ||
-                          snapshot.hasError
-                      ? null
-                      : () => _openUrl(snapshot.data),
-                  icon: snapshot.connectionState == ConnectionState.none ||
-                          snapshot.connectionState == ConnectionState.waiting ||
-                          snapshot.hasError
-                      ? const ElevatedButtonProgressIndicator()
-                      : const Icon(Icons.receipt),
+                const SizedBox(
+                  height: Constants.spacingSmall,
                 ),
-              ),
-            ],
-          );
-        },
+                const Divider(
+                  color: Constants.dividerColor,
+                  height: 1,
+                  thickness: 1,
+                ),
+                Padding(
+                  padding: const EdgeInsets.all(Constants.spacingMiddle),
+                  child: ElevatedButton.icon(
+                    style: ElevatedButton.styleFrom(
+                      maximumSize: const Size.fromHeight(
+                        Constants.elevatedButtonSize,
+                      ),
+                      minimumSize: const Size.fromHeight(
+                        Constants.elevatedButtonSize,
+                      ),
+                    ),
+                    label: const Text('Open Customer Portal'),
+                    onPressed:
+                        snapshot.connectionState == ConnectionState.none ||
+                                snapshot.connectionState ==
+                                    ConnectionState.waiting ||
+                                snapshot.hasError
+                            ? null
+                            : () => _openUrl(snapshot.data),
+                    icon: snapshot.connectionState == ConnectionState.none ||
+                            snapshot.connectionState ==
+                                ConnectionState.waiting ||
+                            snapshot.hasError
+                        ? const ElevatedButtonProgressIndicator()
+                        : const Icon(Icons.receipt),
+                  ),
+                ),
+              ],
+            );
+          },
+        ),
       ),
     );
   }


### PR DESCRIPTION
Several widgets which where rendered within a modal bottom sheet didn't used a `SafeArea` widget in the body of the `Scaffold` widget, so that the action buttons on the bottom of the widget where not rendered in the correct position.

<!--
  Keep PR title verbose enough and add prefix telling about what source it touches e.g "[rss] Add feature xyz" or if the
  the PR is not realated to a source use "[core]", e.g. "[core] Fix xyz".

  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
