### PR TITLE
[core] Add Open Link Action

### DIFF
--- a/app/lib/widgets/item/details/item_details.dart
+++ b/app/lib/widgets/item/details/item_details.dart
@@ -208,7 +208,7 @@ class ItemDetails extends StatelessWidget {
                     Constants.elevatedButtonSize,
                   ),
                 ),
-                label: const Text('Open link'),
+                label: const Text('Open Link'),
                 onPressed: () => _openUrl(item.link),
                 icon: const Icon(Icons.launch),
               ),

--- a/app/lib/widgets/item/preview/utils/item_actions.dart
+++ b/app/lib/widgets/item/preview/utils/item_actions.dart
@@ -6,6 +6,7 @@ import 'package:flutter/services.dart';
 
 import 'package:provider/provider.dart';
 
+import 'package:feeddeck/utils/openurl.dart';
 import 'package:feeddeck/models/item.dart';
 import 'package:feeddeck/repositories/items_repository.dart';
 import 'package:feeddeck/utils/constants.dart';
@@ -59,6 +60,14 @@ class _ItemActionsState extends State<ItemActions> {
         context,
         listen: false,
       ).updateReadState(widget.item.id, !widget.item.isRead);
+    } catch (_) {}
+  }
+
+  /// [_openUrl] opens the item url in the default browser of the current
+  /// device.
+  Future<void> _openUrl() async {
+    try {
+      await openUrl(widget.item.link);
     } catch (_) {}
   }
 
@@ -126,6 +135,15 @@ class _ItemActionsState extends State<ItemActions> {
                 : const Text('Add Bookmark'),
           ),
         ),
+        const PopupMenuItem(
+          value: 'openlink',
+          child: ListTile(
+            leading: Icon(
+              Icons.launch,
+            ),
+            title: Text('Open Link'),
+          ),
+        ),
       ],
     );
 
@@ -138,6 +156,11 @@ class _ItemActionsState extends State<ItemActions> {
       case 'bookmark':
         if (mounted) {
           await _bookmark(context);
+        }
+        break;
+      case 'openlink':
+        if (mounted) {
+          await _openUrl();
         }
         break;
     }
@@ -210,6 +233,20 @@ class _ItemActionsState extends State<ItemActions> {
                 title: widget.item.isBookmarked
                     ? const Text('Remove Bookmark')
                     : const Text('Add Bookmark'),
+              ),
+              const Divider(
+                color: Constants.dividerColor,
+                height: 1,
+                thickness: 1,
+              ),
+              ListTile(
+                mouseCursor: SystemMouseCursors.click,
+                onTap: () async {
+                  Navigator.of(context).pop();
+                  _openUrl();
+                },
+                leading: const Icon(Icons.launch),
+                title: const Text('Open Link'),
               ),
             ],
           ),


### PR DESCRIPTION
This commit adds a new action to the menu shown when a user clicks longer on the item in a column. The new "Open Link" action allows a user to directly open the link of the item, so that the details modal must not be opened anymore to open the link.

<!--
  Keep PR title verbose enough and add prefix telling about what source it touches e.g "[rss] Add feature xyz" or if the
  the PR is not realated to a source use "[core]", e.g. "[core] Fix xyz".

  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
