### PR TITLE
[core] Update macOS GitHub Action Runners

### DIFF
--- a/.github/workflows/continuous-delivery.yaml
+++ b/.github/workflows/continuous-delivery.yaml
@@ -196,7 +196,7 @@ jobs:
   # runs for pull requests and when a new release is published.
   macos:
     name: macOS
-    runs-on: macos-latest
+    runs-on: macos-14
     if: github.event_name == 'pull_request' || (github.event_name == 'release' && github.event.action == 'published')
     permissions:
       contents: write
@@ -371,7 +371,7 @@ jobs:
   # app works. The artifact of the build isn't uploaded / used.
   ios:
     name: iOS
-    runs-on: macos-latest
+    runs-on: macos-14
     if: github.event_name == 'pull_request' || (github.event_name == 'release' && github.event.action == 'published')
     defaults:
       run:


### PR DESCRIPTION
Update the used GitHub Action runners to `macos-14`, see https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/

**Edit:** It looks like this improves the runtime for the macOS and iOS Workflow from round about 6m30s to 4m.

<!--
  Keep PR title verbose enough and add prefix telling about what source it touches e.g "[rss] Add feature xyz" or if the
  the PR is not realated to a source use "[core]", e.g. "[core] Fix xyz".

  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
