### PR TITLE
[core] Add Continuous Delivery Workflow for Linux arm64

### DIFF
--- a/.github/workflows/continuous-delivery.yaml
+++ b/.github/workflows/continuous-delivery.yaml
@@ -245,10 +245,10 @@ jobs:
           upload_url: ${{ github.event.release.upload_url }}
           asset_path: app/build/macos/Build/Products/Release/feeddeck-macos-universal.zip
 
-  # The "Linux" job builds the Flutter Linux app and uploads it to the GitHub release or the pull request. The job only
-  # runs for pull requests and when a new release is published.
-  linux:
-    name: Linux
+  # The "Linux (x86_64)" job builds the Flutter Linux app and uploads it to the GitHub release or the pull request. The
+  # job only runs for pull requests and when a new release is published.
+  linux-x86_64:
+    name: Linux (x86_64)
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request' || (github.event_name == 'release' && github.event.action == 'published')
     permissions:
@@ -311,6 +311,77 @@ jobs:
         with:
           upload_url: ${{ github.event.release.upload_url }}
           asset_path: app/build/feeddeck-linux-x86_64.tar.gz
+
+  # The "Linux (arm64)" job builds the Flutter Linux app and uploads it to the GitHub release or the pull request. The
+  # job only runs for pull requests and when a new release is published.
+  #
+  # NOTE: Normally this job should run for every pull request and when a new release is published, but since we have to
+  # pay for the "ubicloud-standard-2-arm" runner, we only run the job when a new release is published.
+  linux-arm64:
+    name: Linux (arm64)
+    runs-on: ubicloud-standard-2-arm
+    if: github.event_name == 'release' && github.event.action == 'published'
+    # if: github.event_name == 'pull_request' || (github.event_name == 'release' && github.event.action == 'published')
+    permissions:
+      contents: write
+    defaults:
+      run:
+        working-directory: "app"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Packages
+        run: |
+          # Required for Flutter
+          sudo apt-get update -y
+          sudo apt-get install -y ninja-build libgtk-3-dev
+          # Required for Package "media_kit" which is used via "just_audio_media_kit" for Linux and Windows:
+          # See: https://pub.dev/packages/media_kit and https://pub.dev/packages/just_audio_media_kit
+          sudo apt-get install -y libmpv-dev mpv
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.16.9'
+          channel: 'master'
+          cache: true
+          cache-key: 'flutter-:os:-:channel:-:version:-:arch:-:hash:'
+          cache-path: '${{ runner.tool_cache }}/flutter/:channel:-:version:-:arch:'
+
+      - name: Install Dependencies
+        run: |
+          flutter pub get
+
+      - name: Build
+        run: |
+          flutter config --enable-linux-desktop
+          flutter build linux --release --dart-define SUPABASE_URL=${{ secrets.SUPABASE_PROD_URL }} --dart-define SUPABASE_ANON_KEY=${{ secrets.SUPABASE_PROD_ANON_KEY }} --dart-define SUPABASE_SITE_URL=${{ secrets.SUPABASE_PROD_SITE_URL }} --dart-define GOOGLE_CLIENT_ID=${{ secrets.SUPABASE_PROD_GOOGLE_CLIENT_ID }}
+
+      - name: Package
+        run: |
+          cp linux/flatpak/app.feeddeck.feeddeck.desktop build/linux/arm64/release/bundle/
+          cp linux/flatpak/app.feeddeck.feeddeck.metainfo.xml build/linux/arm64/release/bundle/
+          cp linux/flatpak/app.feeddeck.feeddeck.svg build/linux/arm64/release/bundle/
+          cd build
+          cp -r linux/arm64/release/bundle/ feeddeck-linux-arm64
+          tar -czf feeddeck-linux-arm64.tar.gz feeddeck-linux-arm64
+
+      - name: Upload Artifacts (PR)
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: feeddeck-linux-arm64.tar.gz
+          path: app/build/feeddeck-linux-arm64.tar.gz
+          if-no-files-found: error
+
+      - name: Upload Artifacts (Release)
+        uses: shogo82148/actions-upload-release-asset@v1
+        if: ${{ github.event_name == 'release' && github.event.action == 'published' }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: app/build/feeddeck-linux-arm64.tar.gz
 
   # The "Windows" job builds the Flutter Windows app and uploads it to the GitHub release or the pull request. The job
   # only runs for pull requests and when a new release is published.


### PR DESCRIPTION
Until now we had to manually build the app for Linux arm64 when we created a new release. Now we are using ubicloud and the `ubicloud-standard-2-arm` GitHub Action runner to build the app for Linux arm64.

<!--
  Keep PR title verbose enough and add prefix telling about what source it touches e.g "[rss] Add feature xyz" or if the
  the PR is not realated to a source use "[core]", e.g. "[core] Fix xyz".

  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
