### PR TITLE
[core] Fix Password Validations

### DIFF
--- a/app/lib/widgets/reset_password/reset_password.dart
+++ b/app/lib/widgets/reset_password/reset_password.dart
@@ -27,14 +27,22 @@ class _ResetPasswordState extends State<ResetPassword> {
 
   /// [_validatePassword] validates the email address provided via the
   /// [TextField] of the [_passwordController]. The password field can not be
-  /// empty and must have a minimum length of 6 characters.
+  /// empty and must have a minimum length of 8 characters. The password must
+  /// also contain at least one upper case letter, one lower case letter and one
+  /// number.
   String? _validatePassword(String? value) {
     if (value == null || value.isEmpty) {
       return 'Password is required';
     }
 
-    if (value.length < 6) {
-      return 'Password must be a least 6 characters long';
+    if (value.length < 8) {
+      return 'Password must be a least 8 characters long';
+    }
+
+    String pattern = r'^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9]).{8,}$';
+    RegExp regExp = RegExp(pattern);
+    if (!regExp.hasMatch(value)) {
+      return 'Password must contain at least one upper case letter, one lower case letter and one number';
     }
 
     return null;

--- a/app/lib/widgets/settings/profile/settings_profile_password.dart
+++ b/app/lib/widgets/settings/profile/settings_profile_password.dart
@@ -24,14 +24,22 @@ class _SettingsProfilePasswordState extends State<SettingsProfilePassword> {
 
   /// [_validatePassword] validates the email address provided via the
   /// [TextField] of the [_newPasswordController]. The password field can not be
-  /// empty and must have a minimum length of 6 characters.
+  /// empty and must have a minimum length of 8 characters. The password must
+  /// also contain at least one upper case letter, one lower case letter and one
+  /// number.
   String? _validatePassword(String? value) {
     if (value == null || value.isEmpty) {
       return 'Password is required';
     }
 
-    if (value.length < 6) {
-      return 'Password must be a least 6 characters long';
+    if (value.length < 8) {
+      return 'Password must be a least 8 characters long';
+    }
+
+    String pattern = r'^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9]).{8,}$';
+    RegExp regExp = RegExp(pattern);
+    if (!regExp.hasMatch(value)) {
+      return 'Password must contain at least one upper case letter, one lower case letter and one number';
     }
 
     return null;

--- a/app/lib/widgets/signin_with_feeddeck/signin_with_feeddeck.dart
+++ b/app/lib/widgets/signin_with_feeddeck/signin_with_feeddeck.dart
@@ -47,16 +47,13 @@ class _SignInWithFeedDeckState extends State<SignInWithFeedDeck> {
     return null;
   }
 
-  /// [_validatePassword] validates the email address provided via the
-  /// [TextField] of the [_passwordController]. The password field can not be
-  /// empty and must have a minimum length of 6 characters.
+  /// [_validatePassword] validates the password provided via the [TextField] of
+  /// the [_passwordController]. In opposite to the sign up, reset password and
+  /// change password validations, we just check that the password field is not
+  /// empty.
   String? _validatePassword(String? value) {
     if (value == null || value.isEmpty) {
       return 'Password is required';
-    }
-
-    if (value.length < 6) {
-      return 'Password must be a least 6 characters long';
     }
 
     return null;

--- a/app/lib/widgets/signup/signup.dart
+++ b/app/lib/widgets/signup/signup.dart
@@ -56,7 +56,9 @@ class _SignUpState extends State<SignUp> {
 
   /// [_validatePassword] validates the email address provided via the
   /// [TextField] of the [_passwordController]. The password field can not be
-  /// empty and must have a minimum length of 6 characters.
+  /// empty and must have a minimum length of 8 characters. The password must
+  /// also contain at least one upper case letter, one lower case letter and one
+  /// number.
   String? _validatePassword(String? value) {
     if (value == null || value.isEmpty) {
       return 'Password is required';


### PR DESCRIPTION
This commit fixes the password validations. In #130 we introduced some stronger password policies to forbid weak passwords, but forgot to change it in all places. Now the same rules are also applying when a user changes his password or resets his password.

During the sign in we do not use the same rules, to not block users which have already signed up, with a password which doesn't match the rules.

<!--
  Keep PR title verbose enough and add prefix telling about what source it touches e.g "[rss] Add feature xyz" or if the
  the PR is not realated to a source use "[core]", e.g. "[core] Fix xyz".

  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
