### PR TITLE
[mastodon] Add Support for YouTube Videos

### DIFF
--- a/app/lib/widgets/item/details/item_details_mastodon.dart
+++ b/app/lib/widgets/item/details/item_details_mastodon.dart
@@ -7,6 +7,7 @@ import 'package:feeddeck/widgets/item/details/utils/item_description.dart';
 import 'package:feeddeck/widgets/item/details/utils/item_media_gallery.dart';
 import 'package:feeddeck/widgets/item/details/utils/item_subtitle.dart';
 import 'package:feeddeck/widgets/item/details/utils/item_videos.dart';
+import 'package:feeddeck/widgets/item/details/utils/item_youtube/item_youtube_video.dart';
 
 class ItemDetailsMastodon extends StatelessWidget {
   const ItemDetailsMastodon({
@@ -18,6 +19,80 @@ class ItemDetailsMastodon extends StatelessWidget {
   final FDItem item;
   final FDSource source;
 
+  /// [_getYoutubeUrl] returns a YouTube url when the provided [description]
+  /// contains a YouTube link. If the [description] does not contain a YouTube
+  /// link, the function returns `null`.
+  String? _getYoutubeUrl(String description) {
+    final exp = RegExp(r'(?:(?:https?|ftp):\/\/)?[\w/\-?=%.]+\.[\w/\-?=%.]+');
+    final matches = exp.allMatches(description);
+
+    for (var match in matches) {
+      final url = description.substring(match.start, match.end);
+      if (url.startsWith('https://youtu.be/') ||
+          url.startsWith('https://www.youtube.com/watch?') ||
+          url.startsWith('https://m.youtube.com/watch?')) {
+        return url;
+      }
+    }
+
+    return null;
+  }
+
+  /// [_buildDescription] builds the description widget for the item. If the
+  /// description contains a YouTube link, we render the [ItemYoutubeVideo]
+  /// and the [ItemDescription] widgets. If the description does not contain a
+  /// YouTube link, we render the [ItemDescription], [ItemMediaGallery] and
+  /// [ItemVideos] widget.
+  List<Widget> _buildDescription() {
+    final youtubeUrl =
+        item.description != null ? _getYoutubeUrl(item.description!) : null;
+
+    if (youtubeUrl != null) {
+      return [
+        ItemYoutubeVideo(
+          item.media,
+          youtubeUrl,
+        ),
+        ItemDescription(
+          itemDescription: item.description,
+          sourceFormat: DescriptionFormat.html,
+          tagetFormat: DescriptionFormat.markdown,
+          disableImages: true,
+        ),
+      ];
+    }
+
+    return [
+      ItemDescription(
+        itemDescription: item.description,
+        sourceFormat: DescriptionFormat.html,
+        tagetFormat: DescriptionFormat.markdown,
+        disableImages: true,
+      ),
+      const SizedBox(
+        height: Constants.spacingExtraSmall,
+      ),
+      ItemMediaGallery(
+        itemMedias: item.options != null &&
+                item.options!.containsKey('media') &&
+                item.options!['media'] != null
+            ? (item.options!['media'] as List)
+                .map((item) => item as String)
+                .toList()
+            : null,
+      ),
+      ItemVideos(
+        videos: item.options != null &&
+                item.options!.containsKey('videos') &&
+                item.options!['videos'] != null
+            ? (item.options!['videos'] as List)
+                .map((item) => item as String)
+                .toList()
+            : null,
+      ),
+    ];
+  }
+
   @override
   Widget build(BuildContext context) {
     return Column(
@@ -28,32 +103,7 @@ class ItemDetailsMastodon extends StatelessWidget {
           item: item,
           source: source,
         ),
-        ItemDescription(
-          itemDescription: item.description,
-          sourceFormat: DescriptionFormat.html,
-          tagetFormat: DescriptionFormat.markdown,
-        ),
-        const SizedBox(
-          height: Constants.spacingExtraSmall,
-        ),
-        ItemMediaGallery(
-          itemMedias: item.options != null &&
-                  item.options!.containsKey('media') &&
-                  item.options!['media'] != null
-              ? (item.options!['media'] as List)
-                  .map((item) => item as String)
-                  .toList()
-              : null,
-        ),
-        ItemVideos(
-          videos: item.options != null &&
-                  item.options!.containsKey('videos') &&
-                  item.options!['videos'] != null
-              ? (item.options!['videos'] as List)
-                  .map((item) => item as String)
-                  .toList()
-              : null,
-        ),
+        ..._buildDescription(),
       ],
     );
   }


### PR DESCRIPTION
The Mastodon source supports YouTube Videos now. This means that if a Mastodon post contains a link to a YouTube video as user can now directly watch the video within the app.

If the post contains a video we render the YouTube video and the description instead of the description, images and videos.

<!--
  Keep PR title verbose enough and add prefix telling about what source it touches e.g "[rss] Add feature xyz" or if the
  the PR is not realated to a source use "[core]", e.g. "[core] Fix xyz".

  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
