### PR TITLE
[nitter] Add Support for Piped Videos

### DIFF
--- a/app/lib/widgets/item/details/item_details_nitter.dart
+++ b/app/lib/widgets/item/details/item_details_nitter.dart
@@ -5,8 +5,8 @@ import 'package:feeddeck/models/source.dart';
 import 'package:feeddeck/utils/constants.dart';
 import 'package:feeddeck/widgets/item/details/utils/item_description.dart';
 import 'package:feeddeck/widgets/item/details/utils/item_media_gallery.dart';
+import 'package:feeddeck/widgets/item/details/utils/item_piped/item_piped_video.dart';
 import 'package:feeddeck/widgets/item/details/utils/item_subtitle.dart';
-import 'package:feeddeck/widgets/item/details/utils/item_title.dart';
 
 class ItemDetailsNitter extends StatelessWidget {
   const ItemDetailsNitter({
@@ -18,18 +18,37 @@ class ItemDetailsNitter extends StatelessWidget {
   final FDItem item;
   final FDSource source;
 
-  @override
-  Widget build(BuildContext context) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      mainAxisAlignment: MainAxisAlignment.start,
-      children: [
-        ItemTitle(
-          itemTitle: item.title,
-        ),
-        ItemSubtitle(
-          item: item,
-          source: source,
+  /// [_getPipedUrl] returns a Piped url when the provided [description]
+  /// contains a Piped link. If the [description] does not contain a Piped link,
+  /// the function returns `null`.
+  String? _getPipedUrl(String description) {
+    final exp = RegExp(r'(?:(?:https?|ftp):\/\/)?[\w/\-?=%.]+\.[\w/\-?=%.]+');
+    final matches = exp.allMatches(description);
+
+    for (var match in matches) {
+      final url = description.substring(match.start, match.end);
+      if (url.startsWith('https://piped.video/watch?v=') ||
+          url.startsWith('https://piped.video/')) {
+        return url;
+      }
+    }
+
+    return null;
+  }
+
+  /// [_buildDescription] builds the description widget for the item. If the
+  /// description contains a Piped link, we render the [ItemPipedVideo] and the
+  /// [ItemDescription] widgets. If the description does not contain a Piped
+  /// link, we render the [ItemDescription] and [ItemMediaGallery] widget.
+  List<Widget> _buildDescription() {
+    final pipedUrl =
+        item.description != null ? _getPipedUrl(item.description!) : null;
+
+    if (pipedUrl != null) {
+      return [
+        ItemPipedVideo(
+          item.media,
+          pipedUrl,
         ),
         ItemDescription(
           itemDescription: item.description,
@@ -37,16 +56,40 @@ class ItemDetailsNitter extends StatelessWidget {
           tagetFormat: DescriptionFormat.markdown,
           disableImages: true,
         ),
-        const SizedBox(
-          height: Constants.spacingExtraSmall,
+      ];
+    }
+
+    return [
+      ItemDescription(
+        itemDescription: item.description,
+        sourceFormat: DescriptionFormat.html,
+        tagetFormat: DescriptionFormat.markdown,
+        disableImages: true,
+      ),
+      const SizedBox(
+        height: Constants.spacingExtraSmall,
+      ),
+      ItemMediaGallery(
+        itemMedias: item.options != null && item.options!.containsKey('media')
+            ? (item.options!['media'] as List)
+                .map((item) => item as String)
+                .toList()
+            : null,
+      ),
+    ];
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      mainAxisAlignment: MainAxisAlignment.start,
+      children: [
+        ItemSubtitle(
+          item: item,
+          source: source,
         ),
-        ItemMediaGallery(
-          itemMedias: item.options != null && item.options!.containsKey('media')
-              ? (item.options!['media'] as List)
-                  .map((item) => item as String)
-                  .toList()
-              : null,
-        ),
+        ..._buildDescription(),
       ],
     );
   }

--- a/app/lib/widgets/item/details/utils/item_piped/item_piped_video.dart
+++ b/app/lib/widgets/item/details/utils/item_piped/item_piped_video.dart
@@ -1,0 +1,20 @@
+library item_piped_video;
+
+import 'package:flutter/material.dart';
+
+import 'item_piped_video_stub.dart'
+    if (dart.library.io) 'item_piped_video_native.dart'
+    if (dart.library.html) 'item_piped_video_web.dart';
+
+/// The [ItemPipedVideo] class implements a widget that displays a video from
+/// Piped.
+///
+/// This is required because we are using different implementations for the web
+/// and for all other target platforms (Android, iOS, macOS, Windows, Linux). On
+/// the web we display the Piped video via an `iframe` element. On all other
+/// platforms we are using the [piped_client] package to fetch the url of the
+/// Piped video, which can then be displayed via our [ItemVideoPlayer] widget.
+abstract class ItemPipedVideo implements StatefulWidget {
+  factory ItemPipedVideo(String? imageUrl, String videoUrl) =>
+      getItemPipedVideo(imageUrl, videoUrl);
+}

--- a/app/lib/widgets/item/details/utils/item_piped/item_piped_video_native.dart
+++ b/app/lib/widgets/item/details/utils/item_piped/item_piped_video_native.dart
@@ -1,0 +1,125 @@
+import 'package:flutter/material.dart';
+
+import 'package:piped_client/piped_client.dart';
+
+import 'package:feeddeck/widgets/item/details/utils/item_media.dart';
+import 'package:feeddeck/widgets/item/details/utils/item_videos.dart';
+import 'item_piped_video.dart';
+
+/// The [ItemVideoQuality] class represents a list of video qualities for the
+/// requested Piped video and the corresponding audio stream.
+class ItemVideoQualitiesAndAudio {
+  const ItemVideoQualitiesAndAudio({
+    required this.qualities,
+    required this.audio,
+  });
+
+  final List<ItemVideoQuality> qualities;
+  final String audio;
+}
+
+/// [_getVideoId] returns the id of the provide video url, which can be used to
+/// get the video streams via the Piped API.
+String _getVideoId(String videoUrl) {
+  if (videoUrl.startsWith('https://piped.video/watch?v=')) {
+    return videoUrl.replaceFirst(
+      'https://piped.video/watch?v=',
+      '',
+    );
+  }
+
+  if (videoUrl.startsWith('https://piped.video/')) {
+    return videoUrl.replaceFirst(
+      'https://piped.video/',
+      '',
+    );
+  }
+
+  return videoUrl;
+}
+
+class ItemPipedVideoNative extends StatefulWidget implements ItemPipedVideo {
+  const ItemPipedVideoNative({
+    super.key,
+    required this.imageUrl,
+    required this.videoUrl,
+  });
+
+  final String? imageUrl;
+  final String videoUrl;
+
+  @override
+  State<ItemPipedVideoNative> createState() => _ItemPipedVideoNativeState();
+}
+
+class _ItemPipedVideoNativeState extends State<ItemPipedVideoNative> {
+  final piped = PipedClient();
+  late Future<ItemVideoQualitiesAndAudio> _futureFetchVideoAndAudioUrls;
+
+  /// [_fetchVideoAndAudioUrls] fetches the video and audio urls for the
+  /// requested Piped video. Since the video streams do not contain the audio
+  /// stream, we have to fetch the audio stream separately.
+  Future<ItemVideoQualitiesAndAudio> _fetchVideoAndAudioUrls() async {
+    final streams = await piped.streams(_getVideoId(widget.videoUrl));
+
+    return ItemVideoQualitiesAndAudio(
+      qualities: streams.videoStreams
+          .where(
+            (element) =>
+                element.mimeType == 'video/mp4' &&
+                element.format == PipedVideoStreamFormat.mp4,
+          )
+          .map(
+            (element) => ItemVideoQuality(
+              quality: element.quality,
+              video: element.url,
+            ),
+          )
+          .toList(),
+      audio: streams.audioStreams
+          .where((element) => element.mimeType == 'audio/mp4')
+          .map((element) => element.url)
+          .first,
+    );
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    setState(() {
+      _futureFetchVideoAndAudioUrls = _fetchVideoAndAudioUrls();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder(
+      future: _futureFetchVideoAndAudioUrls,
+      builder: (
+        BuildContext context,
+        AsyncSnapshot<ItemVideoQualitiesAndAudio> snapshot,
+      ) {
+        if (snapshot.connectionState == ConnectionState.none ||
+            snapshot.connectionState == ConnectionState.waiting ||
+            snapshot.hasError ||
+            snapshot.data == null ||
+            snapshot.data!.qualities.isEmpty ||
+            snapshot.data!.audio.isEmpty) {
+          return ItemMedia(itemMedia: widget.imageUrl);
+        }
+
+        return ItemVideoPlayer(
+          video: snapshot.data!.qualities.first.video,
+          audio: snapshot.data!.audio,
+          qualities: snapshot.data!.qualities,
+        );
+      },
+    );
+  }
+}
+
+ItemPipedVideo getItemPipedVideo(String? imageUrl, String videoUrl) =>
+    ItemPipedVideoNative(
+      imageUrl: imageUrl,
+      videoUrl: videoUrl,
+    );

--- a/app/lib/widgets/item/details/utils/item_piped/item_piped_video_stub.dart
+++ b/app/lib/widgets/item/details/utils/item_piped/item_piped_video_stub.dart
@@ -1,0 +1,6 @@
+import 'item_piped_video.dart';
+
+ItemPipedVideo getItemPipedVideo(String? imageUrl, String videoUrl) =>
+    throw UnsupportedError(
+      'Can not ItemPipedVideo without the packages dart:html or dart:io',
+    );

--- a/app/lib/widgets/item/details/utils/item_piped/item_piped_video_web.dart
+++ b/app/lib/widgets/item/details/utils/item_piped/item_piped_video_web.dart
@@ -1,0 +1,90 @@
+import 'dart:html'; // ignore: avoid_web_libraries_in_flutter
+
+import 'dart:ui' as ui;
+
+import 'package:flutter/material.dart';
+
+import 'package:feeddeck/utils/constants.dart';
+import 'item_piped_video.dart';
+
+/// [_convertVideoUrl] converts the video url to a format that can be used to
+/// embed the video in an iframe.
+String _convertVideoUrl(String videoUrl) {
+  if (videoUrl.startsWith('https://piped.video/watch?v=')) {
+    return videoUrl.replaceFirst(
+      'https://piped.video/watch?v=',
+      'https://piped.video/embed/',
+    );
+  }
+
+  if (videoUrl.startsWith('https://piped.video/')) {
+    return videoUrl.replaceFirst(
+      'https://piped.video/',
+      'https://piped.video/embed/',
+    );
+  }
+
+  return videoUrl;
+}
+
+class ItemPipedVideoWeb extends StatefulWidget implements ItemPipedVideo {
+  const ItemPipedVideoWeb({
+    super.key,
+    required this.imageUrl,
+    required this.videoUrl,
+  });
+
+  final String? imageUrl;
+  final String videoUrl;
+
+  @override
+  State<ItemPipedVideoWeb> createState() => _ItemPipedVideoWebState();
+}
+
+class _ItemPipedVideoWebState extends State<ItemPipedVideoWeb> {
+  final IFrameElement _iframeElement = IFrameElement();
+
+  @override
+  void initState() {
+    super.initState();
+
+    _iframeElement.src = _convertVideoUrl(widget.videoUrl);
+    _iframeElement.style.border = 'none';
+    _iframeElement.allowFullscreen = true;
+
+    // ignore: undefined_prefixed_name
+    ui.platformViewRegistry.registerViewFactory(
+      widget.videoUrl,
+      (int viewId) => _iframeElement,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.only(
+        bottom: Constants.spacingMiddle,
+      ),
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          return Center(
+            child: SizedBox(
+              width: constraints.maxWidth,
+              height: constraints.maxWidth * 9.0 / 16.0,
+              child: HtmlElementView(
+                key: Key(widget.videoUrl),
+                viewType: widget.videoUrl,
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+ItemPipedVideo getItemPipedVideo(String? imageUrl, String videoUrl) =>
+    ItemPipedVideoWeb(
+      imageUrl: imageUrl,
+      videoUrl: videoUrl,
+    );

--- a/app/lib/widgets/item/details/utils/item_youtube/item_youtube_video_native.dart
+++ b/app/lib/widgets/item/details/utils/item_youtube/item_youtube_video_native.dart
@@ -65,7 +65,8 @@ class _ItemYoutubeVideoNativeState extends State<ItemYoutubeVideoNative> {
         if (snapshot.connectionState == ConnectionState.none ||
             snapshot.connectionState == ConnectionState.waiting ||
             snapshot.hasError ||
-            snapshot.data == null) {
+            snapshot.data == null ||
+            snapshot.data!.isEmpty) {
           return ItemMedia(itemMedia: widget.imageUrl);
         }
 

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -201,6 +201,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.10"
+  dio:
+    dependency: transitive
+    description:
+      name: dio
+      sha256: "797e1e341c3dd2f69f2dad42564a6feff3bfb87187d05abb93b9609e6f1645c3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.4.0"
   fake_async:
     dependency: transitive
     description:
@@ -697,6 +705,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.2"
+  piped_client:
+    dependency: "direct main"
+    description:
+      name: piped_client
+      sha256: "8b96e1f9d8533c1da7eff7fbbd4bf188256fc76a20900d378b52be09418ea771"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.0"
   platform:
     dependency: transitive
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -62,6 +62,7 @@ dependencies:
   media_kit_video: ^1.2.4
   media_kit_libs_video: ^1.0.4
   package_info_plus: ^5.0.1
+  piped_client: ^0.1.0
   provider: ^6.0.4
   purchases_flutter: ^6.19.0
   rxdart: ^0.27.7


### PR DESCRIPTION
The Nitter source now supports playing Piped Videos directly within the app. For this we are checking if the Nitter post contains a piped.video url and if this is the case we are using the newly added `ItemPipedVideo` widget to render the video player, to allow users to directly play the video within the app.

To support Piped videos we had to create a new `ItemPipedVideo` widget, which is very similar to the `ItemYoutubeVideo` widget. This means on the web version of FeedDeck we show the Video via an iframe and on the other platforms via our `ItemVideoPlayer` widget. The main difference between Piped and YouTube widget is the different client we use to fetch the video urls. Besides the Piped API returns two different stream one for the video and one for the audio, so that we had to add an additional `audio` paramter to the `ItemVideoPlayer` widget, which allows us to specify an additional audio source for a video.

NOTE: We had to add support for Piped, because Nitter automatically converts the YouTube urls to the corresponding Piped urls.

<!--
  Keep PR title verbose enough and add prefix telling about what source it touches e.g "[rss] Add feature xyz" or if the
  the PR is not realated to a source use "[core]", e.g. "[core] Fix xyz".

  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
