### PR TITLE
[lemmy] Add Support for Piped Videos

### DIFF
--- a/app/lib/widgets/item/details/item_details_lemmy.dart
+++ b/app/lib/widgets/item/details/item_details_lemmy.dart
@@ -4,6 +4,7 @@ import 'package:feeddeck/models/item.dart';
 import 'package:feeddeck/models/source.dart';
 import 'package:feeddeck/widgets/item/details/utils/item_description.dart';
 import 'package:feeddeck/widgets/item/details/utils/item_media.dart';
+import 'package:feeddeck/widgets/item/details/utils/item_piped/item_piped_video.dart';
 import 'package:feeddeck/widgets/item/details/utils/item_subtitle.dart';
 import 'package:feeddeck/widgets/item/details/utils/item_title.dart';
 import 'package:feeddeck/widgets/item/details/utils/item_videos.dart';
@@ -47,6 +48,14 @@ class ItemDetailsLemmy extends StatelessWidget {
           item.media!.startsWith('https://www.youtube.com/watch?') ||
           item.media!.startsWith('https://m.youtube.com/watch?')) {
         return ItemYoutubeVideo(
+          null,
+          item.media!,
+        );
+      }
+
+      if (item.media!.startsWith('https://piped.video/watch?v=') ||
+          item.media!.startsWith('https://piped.video/')) {
+        return ItemPipedVideo(
           null,
           item.media!,
         );

--- a/supabase/functions/_shared/feed/lemmy.ts
+++ b/supabase/functions/_shared/feed/lemmy.ts
@@ -310,7 +310,12 @@ const getMedia = (entry: FeedEntry): string | undefined => {
        */
       entry.links[0].href.startsWith('https://youtu.be/') ||
       entry.links[0].href.startsWith('https://www.youtube.com/watch?') ||
-      entry.links[0].href.startsWith('https://m.youtube.com/watch?')
+      entry.links[0].href.startsWith('https://m.youtube.com/watch?') ||
+      /**
+       * Piped
+       */
+      entry.links[0].href.startsWith('https://piped.video/watch?v=') ||
+      entry.links[0].href.startsWith('https://piped.video/')
     ) {
       return entry.links[0].href;
     }


### PR DESCRIPTION
If a Lemmy post contains a Piped video it can now by played directly in the app, similar to how it is handled for Nitter posts.

<!--
  Keep PR title verbose enough and add prefix telling about what source it touches e.g "[rss] Add feature xyz" or if the
  the PR is not realated to a source use "[core]", e.g. "[core] Fix xyz".

  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
