### PR TITLE
[mastodon] Add Support for Piped Videos

### DIFF
--- a/app/lib/widgets/item/details/item_details_mastodon.dart
+++ b/app/lib/widgets/item/details/item_details_mastodon.dart
@@ -5,6 +5,7 @@ import 'package:feeddeck/models/source.dart';
 import 'package:feeddeck/utils/constants.dart';
 import 'package:feeddeck/widgets/item/details/utils/item_description.dart';
 import 'package:feeddeck/widgets/item/details/utils/item_media_gallery.dart';
+import 'package:feeddeck/widgets/item/details/utils/item_piped/item_piped_video.dart';
 import 'package:feeddeck/widgets/item/details/utils/item_subtitle.dart';
 import 'package:feeddeck/widgets/item/details/utils/item_videos.dart';
 import 'package:feeddeck/widgets/item/details/utils/item_youtube/item_youtube_video.dart';
@@ -38,6 +39,24 @@ class ItemDetailsMastodon extends StatelessWidget {
     return null;
   }
 
+  /// [_getPipedUrl] returns a Piped url when the provided [description]
+  /// contains a Piped link. If the [description] does not contain a Piped link,
+  /// the function returns `null`.
+  String? _getPipedUrl(String description) {
+    final exp = RegExp(r'(?:(?:https?|ftp):\/\/)?[\w/\-?=%.]+\.[\w/\-?=%.]+');
+    final matches = exp.allMatches(description);
+
+    for (var match in matches) {
+      final url = description.substring(match.start, match.end);
+      if (url.startsWith('https://piped.video/watch?v=') ||
+          url.startsWith('https://piped.video/')) {
+        return url;
+      }
+    }
+
+    return null;
+  }
+
   /// [_buildDescription] builds the description widget for the item. If the
   /// description contains a YouTube link, we render the [ItemYoutubeVideo]
   /// and the [ItemDescription] widgets. If the description does not contain a
@@ -52,6 +71,24 @@ class ItemDetailsMastodon extends StatelessWidget {
         ItemYoutubeVideo(
           item.media,
           youtubeUrl,
+        ),
+        ItemDescription(
+          itemDescription: item.description,
+          sourceFormat: DescriptionFormat.html,
+          tagetFormat: DescriptionFormat.markdown,
+          disableImages: true,
+        ),
+      ];
+    }
+
+    final pipedUrl =
+        item.description != null ? _getPipedUrl(item.description!) : null;
+
+    if (pipedUrl != null) {
+      return [
+        ItemPipedVideo(
+          item.media,
+          pipedUrl,
         ),
         ItemDescription(
           itemDescription: item.description,


### PR DESCRIPTION
If a Mastodon post contains a Piped video it can now be played directly within the app, similar to how it is handled for Nitter posts.

<!--
  Keep PR title verbose enough and add prefix telling about what source it touches e.g "[rss] Add feature xyz" or if the
  the PR is not realated to a source use "[core]", e.g. "[core] Fix xyz".

  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
