### PR TITLE
[4chan] Improve Options Parsing

### DIFF
--- a/supabase/functions/_shared/feed/feed.ts
+++ b/supabase/functions/_shared/feed/feed.ts
@@ -18,7 +18,7 @@ import { getGithubFeed } from './github.ts';
 import { IProfile } from '../models/profile.ts';
 import { getNitterFeed } from './nitter.ts';
 import { getMastodonFeed } from './mastodon.ts';
-import { getFourChanFeed } from './fourchan.ts';
+import { getFourChanFeed, isFourChanUrl } from './fourchan.ts';
 // import { getXFeed } from './x.ts';
 
 /**
@@ -116,6 +116,13 @@ export const getFeed = async (
       );
     case 'rss':
       try {
+        if (source.options?.rss && isFourChanUrl(source.options.rss)) {
+          return await getFourChanFeed(supabaseClient, redisClient, profile, {
+            ...source,
+            options: { fourchan: source.options.rss },
+          }, feedData);
+        }
+
         if (source.options?.rss && isLemmyUrl(source.options.rss)) {
           return await getLemmyFeed(supabaseClient, redisClient, profile, {
             ...source,

--- a/supabase/functions/_shared/feed/fourchan_test.ts
+++ b/supabase/functions/_shared/feed/fourchan_test.ts
@@ -75,23 +75,23 @@ Deno.test('getFourChanFeed', async () => {
       undefined,
     );
     feedutils.assertEqualsSource(source, {
-      'id': 'fourchan-myuser-mycolumn-9e3669d19b675bd57058fd4664205d2a',
+      'id': 'fourchan-myuser-mycolumn-720d65527443fd4e996f83f91a7a5261',
       'columnId': 'mycolumn',
       'userId': 'myuser',
       'type': 'fourchan',
       'title': '/v/ - Video Games',
       'options': {
-        'fourchan': 'v',
+        'fourchan': 'https://boards.4chan.org/v/index.rss',
       },
       'link': 'http://boards.4chan.org/v/./',
     });
     feedutils.assertEqualsItems(items, [
       {
         'id':
-          'fourchan-myuser-mycolumn-9e3669d19b675bd57058fd4664205d2a-4cedc3982b91056cf239c4a546aceca7',
+          'fourchan-myuser-mycolumn-720d65527443fd4e996f83f91a7a5261-4cedc3982b91056cf239c4a546aceca7',
         'userId': 'myuser',
         'columnId': 'mycolumn',
-        'sourceId': 'fourchan-myuser-mycolumn-9e3669d19b675bd57058fd4664205d2a',
+        'sourceId': 'fourchan-myuser-mycolumn-720d65527443fd4e996f83f91a7a5261',
         'title':
           'Will the Cyberpunk sequel manage to get to the level of hype...',
         'link': 'http://boards.4chan.org/v/thread/666978687#666978687',
@@ -103,10 +103,10 @@ Deno.test('getFourChanFeed', async () => {
       },
       {
         'id':
-          'fourchan-myuser-mycolumn-9e3669d19b675bd57058fd4664205d2a-2d682afe971ddf86fb31f588bbc9b808',
+          'fourchan-myuser-mycolumn-720d65527443fd4e996f83f91a7a5261-2d682afe971ddf86fb31f588bbc9b808',
         'userId': 'myuser',
         'columnId': 'mycolumn',
-        'sourceId': 'fourchan-myuser-mycolumn-9e3669d19b675bd57058fd4664205d2a',
+        'sourceId': 'fourchan-myuser-mycolumn-720d65527443fd4e996f83f91a7a5261',
         'title': "new games can't have this feel",
         'link': 'http://boards.4chan.org/v/thread/666978663#666978663',
         'media': 'http://i.4cdn.org/v/1707857926060804s.jpg',


### PR DESCRIPTION
A 4chan source can now also be added via the RSS source type in the Flutter app. If a user provides the RSS feed of an 4chan board, we check if the url is related to 4chan and if this is the case, we use the 4chan
  instead of the RSS source type, similar to how it is handled for other
  sources like Medium, Reddit, etc.

<!--
  Keep PR title verbose enough and add prefix telling about what source it touches e.g "[rss] Add feature xyz" or if the
  the PR is not realated to a source use "[core]", e.g. "[core] Fix xyz".

  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
