### PR TITLE
[core] Use Upstream `just_audio_media_kit` Version

### DIFF
--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -435,12 +435,11 @@ packages:
   just_audio_media_kit:
     dependency: "direct main"
     description:
-      path: "."
-      ref: HEAD
-      resolved-ref: "5980ceac7cc385baf2269eda2dcb024d3e5203cc"
-      url: "https://github.com/feeddeck/just_audio_media_kit.git"
-    source: git
-    version: "1.0.0"
+      name: just_audio_media_kit
+      sha256: "7827b40f1532e93453b0e9f4e32e9a4b45a0e5782e5454b98f0c2edceac8cd4a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   just_audio_platform_interface:
     dependency: transitive
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -51,13 +51,7 @@ dependencies:
   intl: ^0.19.0
   just_audio: ^0.9.32
   just_audio_background: ^0.0.1-beta.10
-  # We use our own fork of the "just_audio_media_kit" package, where we
-  # replaced the "media_kit_libs_windows_audio" with
-  # "media_kit_libs_windows_video" package, so that we can play video files on
-  # Windows via the "media_kit" package.
-  just_audio_media_kit:
-    git:
-      url: https://github.com/feeddeck/just_audio_media_kit.git
+  just_audio_media_kit: ^2.0.1
   media_kit: ^1.1.10+1
   media_kit_video: ^1.2.4
   media_kit_libs_video: ^1.0.4


### PR DESCRIPTION
Use the newest upstream version of the `just_audio_media_kit` package, which removes the hard dependencies on the `media_kit_libs_linux` and `media_kit_libs_windows_audio` packages, so that it shouldn't conflict anymore with the usage of the `media_kit_libs_video` package.

<!--
  Keep PR title verbose enough and add prefix telling about what source it touches e.g "[rss] Add feature xyz" or if the
  the PR is not realated to a source use "[core]", e.g. "[core] Fix xyz".

  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
