### PR TITLE
[core] Fix Blockquote Style

### DIFF
--- a/app/lib/widgets/item/details/utils/item_description.dart
+++ b/app/lib/widgets/item/details/utils/item_description.dart
@@ -54,6 +54,15 @@ class ItemDescription extends StatelessWidget {
         codeblockDecoration: const BoxDecoration(
           color: Constants.secondary,
         ),
+        blockquoteDecoration: const BoxDecoration(
+          color: Constants.secondary,
+          border: Border(
+            left: BorderSide(
+              color: Constants.primary,
+              width: 1,
+            ),
+          ),
+        ),
       ),
       onTapLink: (text, href, title) {
         if (href != null) {

--- a/app/lib/widgets/item/preview/utils/item_description.dart
+++ b/app/lib/widgets/item/preview/utils/item_description.dart
@@ -55,6 +55,15 @@ class ItemDescription extends StatelessWidget {
           codeblockDecoration: const BoxDecoration(
             color: Constants.secondary,
           ),
+          blockquoteDecoration: const BoxDecoration(
+            color: Constants.secondary,
+            border: Border(
+              left: BorderSide(
+                color: Constants.primary,
+                width: 1,
+              ),
+            ),
+          ),
         ),
         onTapLink: (text, href, title) {
           if (href != null) {


### PR DESCRIPTION
This commit fixes the style of blockquotes when we render the item description as Markdown. Until now blockquotes had a weird blue background, so that the text wasn't readable.

Now we are using the surface color as background and we add a border on the left site with the primary color.

We would also like to use italic as font family, but there is currently a bug, so that the defined blockquote style is not applied. See https://github.com/flutter/flutter/issues/81720

<!--
  Keep PR title verbose enough and add prefix telling about what source it touches e.g "[rss] Add feature xyz" or if the
  the PR is not realated to a source use "[core]", e.g. "[core] Fix xyz".

  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
