### PR TITLE
[core] Add Indexes to Improve Query Performance

### DIFF
--- a/supabase/migrations/20240312204702_add_indexes.sql
+++ b/supabase/migrations/20240312204702_add_indexes.sql
@@ -1,0 +1,18 @@
+------------------------------------------------------------------------------------------------------------------------
+-- Create indexes for the "userId" column on the "decks", "columns", "sources", and "items" tables. These indexes are
+-- used to optimize RLS policies and queries that filter by "userId", see
+-- https://supabase.com/docs/guides/database/postgres/row-level-security#add-indexes
+--
+-- Create indexes for the "deckId", "columnId" and "sourceId" columns to optimize queries that filter by these columns.
+------------------------------------------------------------------------------------------------------------------------
+CREATE INDEX IF NOT EXISTS "decks_userId_idx" ON "decks" USING btree ("userId");
+
+CREATE INDEX IF NOT EXISTS "columns_userId_idx" ON "columns" USING btree ("userId");
+CREATE INDEX IF NOT EXISTS "columns_deckId_idx" ON "columns" USING btree ("deckId");
+
+CREATE INDEX IF NOT EXISTS "sources_userId_idx" ON "sources" USING btree ("userId");
+CREATE INDEX IF NOT EXISTS "sources_columnId_idx" ON "sources" USING btree ("columnId");
+
+CREATE INDEX IF NOT EXISTS "items_userId_idx" ON "items" USING btree ("userId");
+CREATE INDEX IF NOT EXISTS "items_columnId_idx" ON "items" USING btree ("columnId");
+CREATE INDEX IF NOT EXISTS "items_sourceId_idx" ON "items" USING btree ("sourceId");


### PR DESCRIPTION
Until now it could happen that the items for a column could not be retrieved from the database, because of the set query timeout. In this case we received the following error:

```
PostgrestException(message: canceling statement due to statement timeout, code: 57014, details: Internal Server Error, hint: null)
```

To fix this issue we added an `items_columnId_idx` index, so that the items for a column are retrieved fast.

We also added some other useful indexes to improve the overall performance of our queries.

Last but not least we also added an index to the `userId` columns as it is recommended by Supabase to improve the performance of our RLS policies.

<!--
  Keep PR title verbose enough and add prefix telling about what source it touches e.g "[rss] Add feature xyz" or if the
  the PR is not realated to a source use "[core]", e.g. "[core] Fix xyz".

  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
