### PR TITLE
[core] Upload Raw Build in Windows CI/CD Pipeline

### DIFF
--- a/.github/workflows/continuous-delivery.yaml
+++ b/.github/workflows/continuous-delivery.yaml
@@ -387,7 +387,7 @@ jobs:
   # only runs for pull requests and when a new release is published.
   windows:
     name: Windows
-    runs-on: windows-latest
+    runs-on: windows-2019
     if: github.event_name == 'pull_request' || (github.event_name == 'release' && github.event.action == 'published')
     permissions:
       contents: write
@@ -416,19 +416,22 @@ jobs:
         run: |
           flutter config --enable-windows-desktop
           flutter build windows --release --dart-define SUPABASE_URL=${{ secrets.SUPABASE_PROD_URL }} --dart-define SUPABASE_ANON_KEY=${{ secrets.SUPABASE_PROD_ANON_KEY }} --dart-define SUPABASE_SITE_URL=${{ secrets.SUPABASE_PROD_SITE_URL }} --dart-define GOOGLE_CLIENT_ID=${{ secrets.SUPABASE_PROD_GOOGLE_CLIENT_ID }}
+      - name: Create Archive
+        run: |
+          Compress-Archive -Path build/windows/x64/runner/Release/* -Destination feeddeck-windows-x86_64.zip
 
       - name: Package
         run: |
           flutter pub run msix:create --output-path build --output-name feeddeck
           cd build
-          7z a -tzip feeddeck-windows-x86_64.zip feeddeck.msix
+          7z a -tzip feeddeck-windows-x86_64-msix.zip feeddeck.msix
 
       - name: Upload Artifacts (PR)
         if: ${{ github.event_name == 'pull_request' }}
         uses: actions/upload-artifact@v4
         with:
           name: feeddeck-windows-x86_64.zip
-          path: app/build/feeddeck-windows-x86_64.zip
+          path: app/feeddeck-windows-x86_64.zip
           if-no-files-found: error
 
       - name: Upload Artifacts (Release)
@@ -436,7 +439,22 @@ jobs:
         if: ${{ github.event_name == 'release' && github.event.action == 'published' }}
         with:
           upload_url: ${{ github.event.release.upload_url }}
-          asset_path: app/build/feeddeck-windows-x86_64.zip
+          asset_path: app/feeddeck-windows-x86_64.zip
+
+      - name: Upload Artifacts (PR)
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: feeddeck-windows-x86_64-msix.zip
+          path: app/build/feeddeck-windows-x86_64-msix.zip
+          if-no-files-found: error
+
+      - name: Upload Artifacts (Release)
+        uses: shogo82148/actions-upload-release-asset@v1
+        if: ${{ github.event_name == 'release' && github.event.action == 'published' }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: app/build/feeddeck-windows-x86_64-msix.zip
 
   # The "iOS" job builds the Flutter iOS app on every pull request. This is only used to test that the build of the iOS
   # app works. The artifact of the build isn't uploaded / used.


### PR DESCRIPTION
Upload the raw build of the app in the Windows CI/CD pipeline, so that we can test the production build during a new release.

We also had to adjust the Windows runner to `windows-2019`, because the build on `windows-latest` and `windows-2022` can not be startet after downloading it.

<!--
  Keep PR title verbose enough and add prefix telling about what source it touches e.g "[rss] Add feature xyz" or if the
  the PR is not realated to a source use "[core]", e.g. "[core] Fix xyz".

  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
