### PR TITLE
[core] Update Flutter to Version 3.24.0

### DIFF
--- a/.github/workflows/continuous-delivery.yaml
+++ b/.github/workflows/continuous-delivery.yaml
@@ -170,7 +170,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.22.2'
+          flutter-version: '3.24.0'
           channel: 'stable'
           cache: true
           cache-key: 'flutter-:os:-:channel:-:version:-:arch:-:hash:'
@@ -214,7 +214,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.22.2'
+          flutter-version: '3.24.0'
           channel: 'stable'
           cache: true
           cache-key: 'flutter-:os:-:channel:-:version:-:arch:-:hash:'
@@ -276,7 +276,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.22.2'
+          flutter-version: '3.24.0'
           channel: 'stable'
           cache: true
           cache-key: 'flutter-:os:-:channel:-:version:-:arch:-:hash:'
@@ -347,7 +347,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.22.2'
+          flutter-version: '3.24.0'
           channel: 'master'
           cache: true
           cache-key: 'flutter-:os:-:channel:-:version:-:arch:-:hash:'
@@ -405,7 +405,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.22.2'
+          flutter-version: '3.24.0'
           channel: 'stable'
           cache: true
           cache-key: 'flutter-:os:-:channel:-:version:-:arch:-:hash:'
@@ -476,7 +476,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.22.2'
+          flutter-version: '3.24.0'
           channel: 'stable'
           cache: true
           cache-key: 'flutter-:os:-:channel:-:version:-:arch:-:hash:'
@@ -511,7 +511,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.22.2'
+          flutter-version: '3.24.0'
           channel: 'stable'
           cache: true
           cache-key: 'flutter-:os:-:channel:-:version:-:arch:-:hash:'

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.22.2'
+          flutter-version: '3.24.0'
           channel: 'stable'
           cache: true
           cache-key: 'flutter-:os:-:channel:-:version:-:arch:-:hash:'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,10 +57,10 @@ check your installed version:
 ```sh
 $ flutter --version
 
-Flutter 3.22.2 • channel stable • https://github.com/flutter/flutter.git
-Framework • revision 761747bfc5 (3 days ago) • 2024-06-05 22:15:13 +0200
-Engine • revision edd8546116
-Tools • Dart 3.4.3 • DevTools 2.34.3
+Flutter 3.24.0 • channel stable • https://github.com/flutter/flutter.git
+Framework • revision 80c2e84975 (8 days ago) • 2024-07-30 23:06:49 +0700
+Engine • revision b8800d88be
+Tools • Dart 3.5.0 • DevTools 2.37.2
 
 $ deno --version
 

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -18,8 +18,8 @@ import 'package:feeddeck/repositories/settings_repository.dart';
 import 'package:feeddeck/utils/constants.dart';
 import 'package:feeddeck/widgets/confirmation/confirmation.dart';
 import 'package:feeddeck/widgets/home/home.dart';
-import 'package:feeddeck/widgets/reset_password/reset_password.dart';
 import 'package:feeddeck/widgets/item/details/utils/item_audio_palyer/item_audio_player_init/item_audio_player_init.dart';
+import 'package:feeddeck/widgets/reset_password/reset_password.dart';
 
 /// Before we are calling [runApp] we have to ensure that the widget bindings
 /// are initialized, so that we can preserve the splash screen until we are done
@@ -159,8 +159,6 @@ class FeedDeckApp extends StatelessWidget {
               onSecondary: Constants.onSecondary,
               error: Constants.error,
               onError: Constants.onError,
-              background: Constants.background,
-              onBackground: Constants.onBackground,
               surface: Constants.surface,
               onSurface: Constants.onSurface,
             ),
@@ -172,32 +170,32 @@ class FeedDeckApp extends StatelessWidget {
               elevation: Constants.appBarElevation,
             ),
             snackBarTheme: const SnackBarThemeData(
-              backgroundColor: Constants.surface,
+              backgroundColor: Constants.secondary,
               contentTextStyle: TextStyle(
                 color: Constants.onSurface,
               ),
             ),
             dialogTheme: const DialogTheme(
-              backgroundColor: Constants.background,
-              surfaceTintColor: Constants.background,
+              backgroundColor: Constants.surface,
+              surfaceTintColor: Constants.surface,
               contentTextStyle: TextStyle(
-                color: Constants.onBackground,
+                color: Constants.onSurface,
               ),
             ),
             popupMenuTheme: const PopupMenuThemeData(
-              color: Constants.background,
-              surfaceTintColor: Constants.background,
+              color: Constants.surface,
+              surfaceTintColor: Constants.surface,
               textStyle: TextStyle(
-                color: Constants.onBackground,
+                color: Constants.onSurface,
               ),
             ),
             drawerTheme: const DrawerThemeData(
-              backgroundColor: Constants.background,
-              surfaceTintColor: Constants.background,
+              backgroundColor: Constants.surface,
+              surfaceTintColor: Constants.surface,
             ),
             bottomSheetTheme: const BottomSheetThemeData(
-              backgroundColor: Constants.background,
-              surfaceTintColor: Constants.background,
+              backgroundColor: Constants.surface,
+              surfaceTintColor: Constants.surface,
             ),
             pageTransitionsTheme: const PageTransitionsTheme(
               builders: {

--- a/app/lib/utils/constants.dart
+++ b/app/lib/utils/constants.dart
@@ -8,12 +8,10 @@ class Constants {
   static const primary = Color(0xff49d3b4);
   static const onPrimary = Color(0xff1f2229);
   static const secondary = Color(0xff353a46);
-  static const onSecondary = Color(0xffe2e4e9);
+  static const onSecondary = Color(0xff49d3b4);
   static const error = Color(0xffde4A40);
   static const onError = Color(0xffe2e4e9);
-  static const background = Color(0xff1f2229);
-  static const onBackground = Color(0xffe2e4e9);
-  static const surface = Color(0xff353a46);
+  static const surface = Color(0xff1f2229);
   static const onSurface = Color(0xffe2e4e9);
   static const canvasColor = Color(0xff1f2229);
   static const appBarBackgroundColor = Colors.transparent;
@@ -23,7 +21,7 @@ class Constants {
   static const secondaryTextColor = Color(0xff9aa1b2);
 
   static const dividerColor = Color(0xff2a2e38);
-  static const backgroundContainerBackgroundColor = Color(0xff14161a);
+  static const surfaceContainerBackgroundColor = Color(0xff14161a);
 
   static const breakpoint = 600.0;
   static const columnWidth = 352.0;

--- a/app/lib/widgets/column/create/create_column.dart
+++ b/app/lib/widgets/column/create/create_column.dart
@@ -164,6 +164,8 @@ class _CreateColumnState extends State<CreateColumn> {
               padding: const EdgeInsets.all(Constants.spacingMiddle),
               child: ElevatedButton.icon(
                 style: ElevatedButton.styleFrom(
+                  backgroundColor: Constants.secondary,
+                  foregroundColor: Constants.onSecondary,
                   maximumSize: const Size.fromHeight(
                     Constants.elevatedButtonSize,
                   ),

--- a/app/lib/widgets/column/header/column_layout_header.dart
+++ b/app/lib/widgets/column/header/column_layout_header.dart
@@ -101,7 +101,7 @@ class _ColumnLayoutHeaderState extends State<ColumnLayoutHeader> {
             ),
           ),
           centerTitle: false,
-          backgroundColor: Constants.background,
+          backgroundColor: Constants.surface,
           title: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
@@ -216,7 +216,7 @@ class _ColumnLayoutHeaderState extends State<ColumnLayoutHeader> {
             width: double.infinity,
             height: _showSettings,
             decoration: const BoxDecoration(
-              color: Constants.backgroundContainerBackgroundColor,
+              color: Constants.surfaceContainerBackgroundColor,
             ),
             padding: const EdgeInsets.all(Constants.spacingMiddle),
             child: ColumnLayoutHeaderSettings(

--- a/app/lib/widgets/column/header/column_layout_header_settings_sources.dart
+++ b/app/lib/widgets/column/header/column_layout_header_settings_sources.dart
@@ -102,6 +102,8 @@ class _ColumnLayoutHeaderSettingsSourcesState
               ..._buildSourcesList(),
               ElevatedButton.icon(
                 style: ElevatedButton.styleFrom(
+                  backgroundColor: Constants.secondary,
+                  foregroundColor: Constants.onSecondary,
                   maximumSize: const Size.fromHeight(
                     Constants.elevatedButtonSize,
                   ),

--- a/app/lib/widgets/column/search/column_layout_search.dart
+++ b/app/lib/widgets/column/search/column_layout_search.dart
@@ -101,7 +101,7 @@ class _ColumnLayoutSearchState extends State<ColumnLayoutSearch> {
             width: double.infinity,
             height: _showFilters,
             decoration: const BoxDecoration(
-              color: Constants.backgroundContainerBackgroundColor,
+              color: Constants.surfaceContainerBackgroundColor,
             ),
             padding: const EdgeInsets.all(Constants.spacingMiddle),
             child: Column(

--- a/app/lib/widgets/confirmation/confirmation.dart
+++ b/app/lib/widgets/confirmation/confirmation.dart
@@ -43,6 +43,8 @@ class _ConfirmationState extends State<Confirmation> {
       case 'change-email-address':
         return ElevatedButton.icon(
           style: ElevatedButton.styleFrom(
+            backgroundColor: Constants.secondary,
+            foregroundColor: Constants.onSecondary,
             maximumSize: const Size.fromHeight(
               Constants.elevatedButtonSize,
             ),
@@ -57,6 +59,8 @@ class _ConfirmationState extends State<Confirmation> {
       case 'confirm-signup':
         return ElevatedButton.icon(
           style: ElevatedButton.styleFrom(
+            backgroundColor: Constants.secondary,
+            foregroundColor: Constants.onSecondary,
             maximumSize: const Size.fromHeight(
               Constants.elevatedButtonSize,
             ),
@@ -71,6 +75,8 @@ class _ConfirmationState extends State<Confirmation> {
       case 'reset-password':
         return ElevatedButton.icon(
           style: ElevatedButton.styleFrom(
+            backgroundColor: Constants.secondary,
+            foregroundColor: Constants.onSecondary,
             maximumSize: const Size.fromHeight(
               Constants.elevatedButtonSize,
             ),

--- a/app/lib/widgets/deck/actions/create_deck.dart
+++ b/app/lib/widgets/deck/actions/create_deck.dart
@@ -179,6 +179,10 @@ class _CreateDeckState extends State<CreateDeck> {
                     decoration: const InputDecoration(
                       border: OutlineInputBorder(),
                       labelText: 'Name',
+                      hintText: 'e.g. News',
+                      hintStyle: TextStyle(
+                        color: Constants.secondaryTextColor,
+                      ),
                     ),
                     validator: (value) => _validateDeckName(value),
                     onFieldSubmitted: (value) => _createDeck(),
@@ -189,6 +193,8 @@ class _CreateDeckState extends State<CreateDeck> {
                   ),
                   ElevatedButton.icon(
                     style: ElevatedButton.styleFrom(
+                      backgroundColor: Constants.secondary,
+                      foregroundColor: Constants.onSecondary,
                       maximumSize: const Size.fromHeight(
                         Constants.elevatedButtonSize,
                       ),

--- a/app/lib/widgets/deck/actions/select_deck.dart
+++ b/app/lib/widgets/deck/actions/select_deck.dart
@@ -110,7 +110,7 @@ class _SelectDeckState extends State<SelectDeck> {
   @override
   Widget build(BuildContext context) {
     return Container(
-      color: Constants.background,
+      color: Constants.surface,
       child: SafeArea(
         child: Scaffold(
           body: Center(

--- a/app/lib/widgets/deck/deck_layout_large.dart
+++ b/app/lib/widgets/deck/deck_layout_large.dart
@@ -222,7 +222,7 @@ class _DeckLayoutLargeState extends State<DeckLayoutLarge> {
                       splashFactory: NoSplash.splashFactory,
                     ),
                     child: NavigationRail(
-                      backgroundColor: Constants.background,
+                      backgroundColor: Constants.surface,
                       selectedIndex: null,
 
                       /// When a user selects a destination in the navigation

--- a/app/lib/widgets/deck/deck_layout_small.dart
+++ b/app/lib/widgets/deck/deck_layout_small.dart
@@ -209,7 +209,7 @@ class DeckLayoutSmall extends StatelessWidget {
                           IconButton(
                             icon: const Icon(
                               Icons.add,
-                              color: Constants.onSecondary,
+                              color: Constants.onSurface,
                             ),
                             onPressed: () {
                               showModalBottomSheet(
@@ -248,7 +248,7 @@ class DeckLayoutSmall extends StatelessWidget {
                           IconButton(
                             icon: const Icon(
                               Icons.settings,
-                              color: Constants.onSecondary,
+                              color: Constants.onSurface,
                             ),
                             onPressed: () {
                               Navigator.push(

--- a/app/lib/widgets/fogot_password/fogot_password.dart
+++ b/app/lib/widgets/fogot_password/fogot_password.dart
@@ -169,6 +169,8 @@ class _FogotPasswordState extends State<FogotPassword> {
                   ),
                   ElevatedButton.icon(
                     style: ElevatedButton.styleFrom(
+                      backgroundColor: Constants.secondary,
+                      foregroundColor: Constants.onSecondary,
                       maximumSize: const Size.fromHeight(
                         Constants.elevatedButtonSize,
                       ),

--- a/app/lib/widgets/home/home.dart
+++ b/app/lib/widgets/home/home.dart
@@ -43,19 +43,21 @@ class _HomeState extends State<Home> {
         if (uri
             .toString()
             .startsWith('app.feeddeck.feeddeck://signin-callback/')) {
-          Provider.of<AppRepository>(context, listen: false)
-              .signInWithCallback(uri)
-              .then((_) {
-            WidgetsBinding.instance.addPostFrameCallback((_) {
-              Navigator.pushAndRemoveUntil(
-                context,
-                MaterialPageRoute(
-                  builder: (BuildContext context) => const DeckLayout(),
-                ),
-                (route) => false,
-              );
-            });
-          }).catchError((_) {});
+          if (mounted) {
+            Provider.of<AppRepository>(context, listen: false)
+                .signInWithCallback(uri)
+                .then((_) {
+              WidgetsBinding.instance.addPostFrameCallback((_) {
+                Navigator.pushAndRemoveUntil(
+                  context,
+                  MaterialPageRoute(
+                    builder: (BuildContext context) => const DeckLayout(),
+                  ),
+                  (route) => false,
+                );
+              });
+            }).catchError((_) {});
+          }
         }
       });
     }

--- a/app/lib/widgets/item/details/item_details.dart
+++ b/app/lib/widgets/item/details/item_details.dart
@@ -203,6 +203,8 @@ class ItemDetails extends StatelessWidget {
               padding: const EdgeInsets.all(Constants.spacingMiddle),
               child: ElevatedButton.icon(
                 style: ElevatedButton.styleFrom(
+                  backgroundColor: Constants.secondary,
+                  foregroundColor: Constants.onSecondary,
                   maximumSize: const Size.fromHeight(
                     Constants.elevatedButtonSize,
                   ),

--- a/app/lib/widgets/item/details/utils/item_audio_palyer/item_audio_player_seekbar.dart
+++ b/app/lib/widgets/item/details/utils/item_audio_palyer/item_audio_player_seekbar.dart
@@ -62,7 +62,7 @@ class _ItemAudioPlayerSeekBarState extends State<ItemAudioPlayerSeekBar> {
           data: _sliderThemeData.copyWith(
             thumbShape: HiddenThumbComponentShape(),
             activeTrackColor: Constants.secondary,
-            inactiveTrackColor: Constants.backgroundContainerBackgroundColor,
+            inactiveTrackColor: Constants.surfaceContainerBackgroundColor,
           ),
           child: ExcludeSemantics(
             child: Slider(

--- a/app/lib/widgets/item/details/utils/item_videos.dart
+++ b/app/lib/widgets/item/details/utils/item_videos.dart
@@ -104,7 +104,7 @@ class _ItemVideoPlayerState extends State<ItemVideoPlayer> {
                   right: Constants.spacingMiddle,
                 ),
                 decoration: const BoxDecoration(
-                  color: Constants.background,
+                  color: Constants.surface,
                   borderRadius: BorderRadius.all(
                     Radius.circular(Constants.spacingMiddle),
                   ),

--- a/app/lib/widgets/item/preview/utils/item_actions.dart
+++ b/app/lib/widgets/item/preview/utils/item_actions.dart
@@ -195,7 +195,7 @@ class _ItemActionsState extends State<ItemActions> {
               right: Constants.spacingMiddle,
             ),
             decoration: const BoxDecoration(
-              color: Constants.background,
+              color: Constants.surface,
               borderRadius: BorderRadius.all(
                 Radius.circular(Constants.spacingMiddle),
               ),

--- a/app/lib/widgets/reset_password/reset_password.dart
+++ b/app/lib/widgets/reset_password/reset_password.dart
@@ -125,6 +125,8 @@ class _ResetPasswordState extends State<ResetPassword> {
         ),
         ElevatedButton.icon(
           style: ElevatedButton.styleFrom(
+            backgroundColor: Constants.secondary,
+            foregroundColor: Constants.onSecondary,
             maximumSize: const Size.fromHeight(
               Constants.elevatedButtonSize,
             ),
@@ -152,6 +154,8 @@ class _ResetPasswordState extends State<ResetPassword> {
       ),
       ElevatedButton.icon(
         style: ElevatedButton.styleFrom(
+          backgroundColor: Constants.secondary,
+          foregroundColor: Constants.onSecondary,
           maximumSize: const Size.fromHeight(
             Constants.elevatedButtonSize,
           ),

--- a/app/lib/widgets/set_settings/set_settings.dart
+++ b/app/lib/widgets/set_settings/set_settings.dart
@@ -235,6 +235,8 @@ class _SetSettingsState extends State<SetSettings> {
                   ),
                   ElevatedButton.icon(
                     style: ElevatedButton.styleFrom(
+                      backgroundColor: Constants.secondary,
+                      foregroundColor: Constants.onSecondary,
                       maximumSize: const Size.fromHeight(
                         Constants.elevatedButtonSize,
                       ),
@@ -253,6 +255,8 @@ class _SetSettingsState extends State<SetSettings> {
                   ),
                   ElevatedButton.icon(
                     style: ElevatedButton.styleFrom(
+                      backgroundColor: Constants.secondary,
+                      foregroundColor: Constants.onSecondary,
                       maximumSize: const Size.fromHeight(
                         Constants.elevatedButtonSize,
                       ),

--- a/app/lib/widgets/settings/accounts/settings_accounts_github.dart
+++ b/app/lib/widgets/settings/accounts/settings_accounts_github.dart
@@ -290,6 +290,8 @@ class _SettingsAccountsGithubAddState extends State<SettingsAccountsGithubAdd> {
               padding: const EdgeInsets.all(Constants.spacingMiddle),
               child: ElevatedButton.icon(
                 style: ElevatedButton.styleFrom(
+                  backgroundColor: Constants.secondary,
+                  foregroundColor: Constants.onSecondary,
                   maximumSize: const Size.fromHeight(
                     Constants.elevatedButtonSize,
                   ),

--- a/app/lib/widgets/settings/accounts/utils/settings_accounts_actions.dart
+++ b/app/lib/widgets/settings/accounts/utils/settings_accounts_actions.dart
@@ -28,7 +28,7 @@ class SettingsAccountsActions extends StatelessWidget {
           right: Constants.spacingMiddle,
         ),
         decoration: const BoxDecoration(
-          color: Constants.background,
+          color: Constants.surface,
           borderRadius: BorderRadius.all(
             Radius.circular(Constants.spacingMiddle),
           ),

--- a/app/lib/widgets/settings/profile/settings_profile_customer_portal.dart
+++ b/app/lib/widgets/settings/profile/settings_profile_customer_portal.dart
@@ -212,6 +212,8 @@ class _SettingsProfileCustomerPortalModalState
                   padding: const EdgeInsets.all(Constants.spacingMiddle),
                   child: ElevatedButton.icon(
                     style: ElevatedButton.styleFrom(
+                      backgroundColor: Constants.secondary,
+                      foregroundColor: Constants.onSecondary,
                       maximumSize: const Size.fromHeight(
                         Constants.elevatedButtonSize,
                       ),

--- a/app/lib/widgets/settings/profile/settings_profile_signout.dart
+++ b/app/lib/widgets/settings/profile/settings_profile_signout.dart
@@ -162,7 +162,7 @@ class SettingsProfileSignOutActions extends StatelessWidget {
           right: Constants.spacingMiddle,
         ),
         decoration: const BoxDecoration(
-          color: Constants.background,
+          color: Constants.surface,
           borderRadius: BorderRadius.all(
             Radius.circular(Constants.spacingMiddle),
           ),

--- a/app/lib/widgets/settings/settings.dart
+++ b/app/lib/widgets/settings/settings.dart
@@ -39,7 +39,7 @@ class _SettingsState extends State<Settings> {
   @override
   Widget build(BuildContext context) {
     return Container(
-      color: Constants.background,
+      color: Constants.surface,
       child: SafeArea(
         child: Scaffold(
           appBar: AppBar(

--- a/app/lib/widgets/signin_with_feeddeck/signin_with_feeddeck.dart
+++ b/app/lib/widgets/signin_with_feeddeck/signin_with_feeddeck.dart
@@ -194,6 +194,8 @@ class _SignInWithFeedDeckState extends State<SignInWithFeedDeck> {
                   ),
                   ElevatedButton.icon(
                     style: ElevatedButton.styleFrom(
+                      backgroundColor: Constants.secondary,
+                      foregroundColor: Constants.onSecondary,
                       maximumSize: const Size.fromHeight(
                         Constants.elevatedButtonSize,
                       ),

--- a/app/lib/widgets/signup/signup.dart
+++ b/app/lib/widgets/signup/signup.dart
@@ -231,6 +231,8 @@ class _SignUpState extends State<SignUp> {
                   ),
                   ElevatedButton.icon(
                     style: ElevatedButton.styleFrom(
+                      backgroundColor: Constants.secondary,
+                      foregroundColor: Constants.onSecondary,
                       maximumSize: const Size.fromHeight(
                         Constants.elevatedButtonSize,
                       ),

--- a/app/lib/widgets/source/add/add_source.dart
+++ b/app/lib/widgets/source/add/add_source.dart
@@ -151,10 +151,7 @@ class _AddSourceState extends State<AddSource> {
                     style: TextStyle(
                       /// Since we are using the brand color as background
                       /// color, we are using the same color as for the icon
-                      /// as text color (source_icon.dart). If we decide later
-                      /// to use a generic color as background the following
-                      /// line can be used:
-                      /// color: Constants.onSecondary,
+                      /// as text color (source_icon.dart).
                       color: _sourceTypeValues[index].fgColor,
                     ),
                   ),

--- a/app/lib/widgets/source/add/add_source_form.dart
+++ b/app/lib/widgets/source/add/add_source_form.dart
@@ -66,6 +66,8 @@ class AddSourceForm extends StatelessWidget {
           padding: const EdgeInsets.all(Constants.spacingMiddle),
           child: ElevatedButton.icon(
             style: ElevatedButton.styleFrom(
+              backgroundColor: Constants.secondary,
+              foregroundColor: Constants.onSecondary,
               maximumSize: const Size.fromHeight(
                 Constants.elevatedButtonSize,
               ),

--- a/app/macos/Podfile.lock
+++ b/app/macos/Podfile.lock
@@ -120,7 +120,7 @@ SPEC CHECKSUMS:
   media_kit_native_event_loop: 81fd5b45192b72f8b5b69eaf5b540f45777eb8d5
   media_kit_video: c75b07f14d59706c775778e4dd47dd027de8d1e5
   package_info_plus: fa739dd842b393193c5ca93c26798dff6e3d0e0c
-  path_provider_foundation: 3784922295ac71e43754bd15e0653ccfd36a147c
+  path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
   purchases_flutter: 3407100959d2aeb636507b2c98970d850dae57ae
   PurchasesHybridCommon: 4022d5944cb30ec44ba5159e42aa161fe0e30175
   RevenueCat: 3d934653b7e8b09af88fd47e9e84cfaf5d0a89ba
@@ -129,7 +129,7 @@ SPEC CHECKSUMS:
   shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
   sign_in_with_apple: a9e97e744e8edc36aefc2723111f652102a7a727
   sqflite: 673a0e54cc04b7d6dba8d24fb8095b31c3a99eec
-  url_launcher_macos: d2691c7dd33ed713bf3544850a623080ec693d95
+  url_launcher_macos: 5f437abeda8c85500ceb03f5c1938a8c5a705399
   wakelock_plus: 4783562c9a43d209c458cb9b30692134af456269
   window_manager: 3a1844359a6295ab1e47659b1a777e36773cd6e8
 

--- a/app/macos/Runner/AppDelegate.swift
+++ b/app/macos/Runner/AppDelegate.swift
@@ -1,7 +1,7 @@
 import Cocoa
 import FlutterMacOS
 
-@NSApplicationMain
+@main
 class AppDelegate: FlutterAppDelegate {
   override func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
     return true

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -21,10 +21,10 @@ packages:
     dependency: transitive
     description:
       name: app_links_linux
-      sha256: "567139eca3ca9fb113f2082f3aaa75a26f30f0ebdbe5fa7f09a3913c5bebd630"
+      sha256: f5f7173a78609f3dfd4c2ff2c95bd559ab43c80a87dc6a095921d96c05688c81
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.3"
   app_links_platform_interface:
     dependency: transitive
     description:
@@ -37,18 +37,18 @@ packages:
     dependency: transitive
     description:
       name: app_links_web
-      sha256: "74586ed5f3c4786341e82a0fa43c39ec3f13108a550f74e80d8bf68aa11349d1"
+      sha256: af060ed76183f9e2b87510a9480e56a5352b6c249778d07bd2c95fc35632a555
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.3"
+    version: "1.0.4"
   archive:
     dependency: transitive
     description:
       name: archive
-      sha256: "22600aa1e926be775fa5fe7e6894e7fb3df9efda8891c73f70fb3262399a432d"
+      sha256: cb6a278ef2dbb298455e1a713bda08524a175630ec643a242c399c932a0a1f7d
       url: "https://pub.dev"
     source: hosted
-    version: "3.4.10"
+    version: "3.6.1"
   args:
     dependency: transitive
     description:
@@ -109,34 +109,34 @@ packages:
     dependency: "direct main"
     description:
       name: cached_network_image
-      sha256: "28ea9690a8207179c319965c13cd8df184d5ee721ae2ce60f398ced1219cea1f"
+      sha256: "4a5d8d2c728b0f3d0245f69f921d7be90cae4c2fd5288f773088672c0893f819"
       url: "https://pub.dev"
     source: hosted
-    version: "3.3.1"
+    version: "3.4.0"
   cached_network_image_platform_interface:
     dependency: transitive
     description:
       name: cached_network_image_platform_interface
-      sha256: "9e90e78ae72caa874a323d78fa6301b3fb8fa7ea76a8f96dc5b5bf79f283bf2f"
+      sha256: ff0c949e323d2a1b52be73acce5b4a7b04063e61414c8ca542dbba47281630a7
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.0"
+    version: "4.1.0"
   cached_network_image_web:
     dependency: transitive
     description:
       name: cached_network_image_web
-      sha256: "42a835caa27c220d1294311ac409a43361088625a4f23c820b006dd9bffb3316"
+      sha256: "6322dde7a5ad92202e64df659241104a43db20ed594c41ca18de1014598d7996"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.3.0"
   carousel_slider:
     dependency: "direct main"
     description:
       name: carousel_slider
-      sha256: "9c695cc963bf1d04a47bd6021f68befce8970bcd61d24938e1fb0918cf5d9c42"
+      sha256: "7b006ec356205054af5beaef62e2221160ea36b90fb70a35e4deacd49d0349ae"
       url: "https://pub.dev"
     source: hosted
-    version: "4.2.1"
+    version: "5.0.0"
   characters:
     dependency: transitive
     description:
@@ -185,14 +185,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.0"
-  convert:
-    dependency: transitive
-    description:
-      name: convert
-      sha256: "0f08b14755d163f6e2134cb58222dd25ea2a2ee8a195e53983d57c075324d592"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.1.1"
   crypto:
     dependency: "direct main"
     description:
@@ -229,10 +221,18 @@ packages:
     dependency: transitive
     description:
       name: dio
-      sha256: "49af28382aefc53562459104f64d16b9dfd1e8ef68c862d5af436cc8356ce5a8"
+      sha256: e17f6b3097b8c51b72c74c9f071a605c47bcc8893839bd66732457a5ebe73714
       url: "https://pub.dev"
     source: hosted
-    version: "5.4.1"
+    version: "5.5.0+1"
+  dio_web_adapter:
+    dependency: transitive
+    description:
+      name: dio_web_adapter
+      sha256: "36c5b2d79eb17cdae41e974b7a8284fec631651d2a6f39a8a2ff22327e90aeac"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
   fake_async:
     dependency: transitive
     description:
@@ -298,10 +298,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_markdown
-      sha256: "2e8a801b1ded5ea001a4529c97b1f213dcb11c6b20668e081cafb23468593514"
+      sha256: a23c41ee57573e62fc2190a1f36a0480c4d90bde3a8a8d7126e5d5992fb53fb7
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.3"
+    version: "0.7.3+1"
   flutter_native_splash:
     dependency: "direct main"
     description:
@@ -324,10 +324,10 @@ packages:
     dependency: transitive
     description:
       name: freezed_annotation
-      sha256: c3fd9336eb55a38cc1bbd79ab17573113a8deccd0ecbbf926cca3c62803b5c2d
+      sha256: c2e2d632dd9b8a2b7751117abcfc2b4888ecfe181bd9fca7170d9ef02e595fe2
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.1"
+    version: "2.4.4"
   functions_client:
     dependency: transitive
     description:
@@ -340,10 +340,10 @@ packages:
     dependency: transitive
     description:
       name: get_it
-      sha256: e6017ce7fdeaf218dc51a100344d8cb70134b80e28b760f8bb23c242437bafd7
+      sha256: d85128a5dae4ea777324730dc65edd9c9f43155c109d5cc0a69cab74139fbac1
       url: "https://pub.dev"
     source: hosted
-    version: "7.6.7"
+    version: "7.7.0"
   gotrue:
     dependency: transitive
     description:
@@ -428,10 +428,10 @@ packages:
     dependency: transitive
     description:
       name: json_annotation
-      sha256: b10a7b2ff83d83c777edba3c6a0f97045ddadd56c944e1a23a3fdf43a1bf4467
+      sha256: "1ce844379ca14835a50d2f019a3099f419082cfdd231cd86a142af94dd5c6bb1"
       url: "https://pub.dev"
     source: hosted
-    version: "4.8.1"
+    version: "4.9.0"
   just_audio:
     dependency: "direct main"
     description:
@@ -484,18 +484,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
+      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.4"
+    version: "10.0.5"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
+      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "3.0.5"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -524,10 +524,10 @@ packages:
     dependency: transitive
     description:
       name: markdown
-      sha256: "1b134d9f8ff2da15cb298efe6cd8b7d2a78958c1b00384ebcbdf13fe340a6c90"
+      sha256: ef2a1298144e3f985cc736b22e0ccdaf188b5b3970648f2d9dc13efd1d9df051
       url: "https://pub.dev"
     source: hosted
-    version: "7.2.1"
+    version: "7.2.2"
   matcher:
     dependency: transitive
     description:
@@ -540,10 +540,10 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.11.1"
   media_kit:
     dependency: "direct main"
     description:
@@ -620,10 +620,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.15.0"
   mime:
     dependency: transitive
     description:
@@ -652,10 +652,10 @@ packages:
     dependency: transitive
     description:
       name: octo_image
-      sha256: "45b40f99622f11901238e18d48f5f12ea36426d8eced9f4cbf58479c7aa2430d"
+      sha256: "34faa6639a78c7e3cbe79be6f9f96535867e879748ade7d17c9b1ae7536293bd"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   package_config:
     dependency: transitive
     description:
@@ -692,26 +692,26 @@ packages:
     dependency: transitive
     description:
       name: path_provider
-      sha256: c9e7d3a4cd1410877472158bee69963a4579f78b68c65a2b7d40d1a7a88bb161
+      sha256: fec0d61223fba3154d87759e3cc27fe2c8dc498f6386c6d6fc80d1afdd1bf378
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.3"
+    version: "2.1.4"
   path_provider_android:
     dependency: transitive
     description:
       name: path_provider_android
-      sha256: "477184d672607c0a3bf68fbbf601805f92ef79c82b64b4d6eb318cbca4c48668"
+      sha256: "490539678396d4c3c0b06efdaab75ae60675c3e0c66f72bc04c2e2c1e0e2abeb"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.2"
+    version: "2.2.9"
   path_provider_foundation:
     dependency: transitive
     description:
       name: path_provider_foundation
-      sha256: "5a7999be66e000916500be4f15a3633ebceb8302719b47b9cc49ce924125350f"
+      sha256: f234384a3fdd67f989b4d54a5d73ca2a6c422fa55ae694381ae0f4375cd1ea16
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.2"
+    version: "2.4.0"
   path_provider_linux:
     dependency: transitive
     description:
@@ -732,10 +732,10 @@ packages:
     dependency: transitive
     description:
       name: path_provider_windows
-      sha256: "8bc9f22eee8690981c22aa7fc602f5c85b497a6fb2ceb35ee5a5e5ed85ad8170"
+      sha256: bd6f00dbd873bfb70d0761682da2b3a2c2fccc2b9e84c495821639601d81afe7
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.1"
+    version: "2.3.0"
   petitparser:
     dependency: transitive
     description:
@@ -756,10 +756,10 @@ packages:
     dependency: transitive
     description:
       name: platform
-      sha256: "12220bb4b65720483f8fa9450b4332347737cf8213dd2840d8b2c823e47243ec"
+      sha256: "9b71283fc13df574056616011fb138fd3b793ea47cc509c189a6c3fa5f8a1a65"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.4"
+    version: "3.1.5"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -768,14 +768,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.8"
-  pointycastle:
-    dependency: transitive
-    description:
-      name: pointycastle
-      sha256: "43ac87de6e10afabc85c445745a7b799e04de84cebaa4fd7bf55a5e1e9604d29"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.7.4"
   postgrest:
     dependency: transitive
     description:
@@ -908,10 +900,10 @@ packages:
     dependency: "direct main"
     description:
       name: shared_preferences
-      sha256: c3f888ba2d659f3e75f4686112cc1e71f46177f74452d40d8307edc332296ead
+      sha256: c272f9cabca5a81adc9b0894381e9c1def363e980f960fa903c604c471b22f68
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.0"
+    version: "2.3.1"
   shared_preferences_android:
     dependency: transitive
     description:
@@ -948,10 +940,10 @@ packages:
     dependency: transitive
     description:
       name: shared_preferences_web
-      sha256: "3a293170d4d9403c3254ee05b84e62e8a9b3c5808ebd17de6a33fe9ea6457936"
+      sha256: "59dc807b94d29d52ddbb1b3c0d3b9d0a67fc535a64e62a5542c8db0513fcb6c2"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.0"
+    version: "2.4.1"
   shared_preferences_windows:
     dependency: transitive
     description:
@@ -1017,10 +1009,10 @@ packages:
     dependency: transitive
     description:
       name: sqflite_common
-      sha256: "28d8c66baee4968519fb8bd6cdbedad982d6e53359091f0b74544a9f32ec72d5"
+      sha256: "3da423ce7baf868be70e2c0976c28a1bb2f73644268b7ffa7d2e08eab71f16a4"
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.3"
+    version: "2.5.4"
   stack_trace:
     dependency: transitive
     description:
@@ -1089,10 +1081,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.0"
+    version: "0.7.2"
   timeago:
     dependency: "direct main"
     description:
@@ -1129,10 +1121,10 @@ packages:
     dependency: transitive
     description:
       name: universal_platform
-      sha256: d315be0f6641898b280ffa34e2ddb14f3d12b1a37882557869646e0cc363d0cc
+      sha256: "64e16458a0ea9b99260ceb5467a214c1f298d647c659af1bff6d3bf82536b1ec"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0+1"
+    version: "1.1.0"
   uri_parser:
     dependency: transitive
     description:
@@ -1153,34 +1145,34 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_android
-      sha256: d4ed0711849dd8e33eb2dd69c25db0d0d3fdc37e0a62e629fe32f57a22db2745
+      sha256: "94d8ad05f44c6d4e2ffe5567ab4d741b82d62e3c8e288cc1fcea45965edf47c9"
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.0"
+    version: "6.3.8"
   url_launcher_ios:
     dependency: transitive
     description:
       name: url_launcher_ios
-      sha256: "75bb6fe3f60070407704282a2d295630cab232991eb52542b18347a8a941df03"
+      sha256: e43b677296fadce447e987a2f519dcf5f6d1e527dc35d01ffab4fff5b8a7063e
       url: "https://pub.dev"
     source: hosted
-    version: "6.2.4"
+    version: "6.3.1"
   url_launcher_linux:
     dependency: transitive
     description:
       name: url_launcher_linux
-      sha256: ab360eb661f8879369acac07b6bb3ff09d9471155357da8443fd5d3cf7363811
+      sha256: e2b9622b4007f97f504cd64c0128309dfb978ae66adbe944125ed9e1750f06af
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.1"
+    version: "3.2.0"
   url_launcher_macos:
     dependency: transitive
     description:
       name: url_launcher_macos
-      sha256: b7244901ea3cf489c5335bdacda07264a6e960b1c1b1a9f91e4bc371d9e68234
+      sha256: "9a1a42d5d2d95400c795b2914c36fdcb525870c752569438e4ebb09a2b5d90de"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "3.2.0"
   url_launcher_platform_interface:
     dependency: transitive
     description:
@@ -1193,26 +1185,26 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_web
-      sha256: "3692a459204a33e04bc94f5fb91158faf4f2c8903281ddd82915adecdb1a901d"
+      sha256: "772638d3b34c779ede05ba3d38af34657a05ac55b06279ea6edd409e323dca8e"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.0"
+    version: "2.3.3"
   url_launcher_windows:
     dependency: transitive
     description:
       name: url_launcher_windows
-      sha256: ecf9725510600aa2bb6d7ddabe16357691b6d2805f66216a97d1b881e21beff7
+      sha256: "49c10f879746271804767cb45551ec5592cdab00ee105c06dddde1a98f73b185"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.1"
+    version: "3.1.2"
   uuid:
     dependency: transitive
     description:
       name: uuid
-      sha256: "814e9e88f21a176ae1359149021870e87f7cddaf633ab678a5d2b0bff7fd1ba8"
+      sha256: "83d37c7ad7aaf9aa8e275490669535c8080377cfa7a7004c24dfac53afffaa90"
       url: "https://pub.dev"
     source: hosted
-    version: "4.4.0"
+    version: "4.4.2"
   vector_math:
     dependency: transitive
     description:
@@ -1225,10 +1217,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
+      sha256: f652077d0bdf60abe4c1f6377448e8655008eef28f128bc023f7b5e8dfeb48fc
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.1"
+    version: "14.2.4"
   volume_controller:
     dependency: transitive
     description:
@@ -1241,10 +1233,10 @@ packages:
     dependency: transitive
     description:
       name: wakelock_plus
-      sha256: "14758533319a462ffb5aa3b7ddb198e59b29ac3b02da14173a1715d65d4e6e68"
+      sha256: "4fa83a128b4127619e385f686b4f080a5d2de46cff8e8c94eccac5fcf76550e5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.5"
+    version: "1.2.7"
   wakelock_plus_platform_interface:
     dependency: transitive
     description:
@@ -1265,18 +1257,18 @@ packages:
     dependency: transitive
     description:
       name: web_socket_channel
-      sha256: "1d8e795e2a8b3730c41b8a98a2dff2e0fb57ae6f0764a1c46ec5915387d257b2"
+      sha256: "58c6666b342a38816b2e7e50ed0f1e261959630becd4c879c4f26bfa14aa5a42"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.4"
+    version: "2.4.5"
   win32:
     dependency: transitive
     description:
       name: win32
-      sha256: a79dbe579cb51ecd6d30b17e0cae4e0ea15e2c0e66f69ad4198f22a6789e94f4
+      sha256: "015002c060f1ae9f41a818f2d5640389cc05283e368be19dc8d77cecb43c40c9"
       url: "https://pub.dev"
     source: hosted
-    version: "5.5.1"
+    version: "5.5.3"
   window_manager:
     dependency: "direct main"
     description:
@@ -1326,5 +1318,5 @@ packages:
     source: hosted
     version: "2.2.1"
 sdks:
-  dart: ">=3.4.0 <4.0.0"
+  dart: ">=3.5.0 <4.0.0"
   flutter: ">=3.22.0"

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -19,7 +19,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.4.1+12
 
 environment:
-  sdk: '>=3.3.0 <4.0.0'
+  sdk: ^3.5.0
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions
@@ -39,7 +39,7 @@ dependencies:
 
   app_links: ^6.1.4
   cached_network_image: ^3.3.1
-  carousel_slider: ^4.2.1
+  carousel_slider: ^5.0.0
   collection: ^1.17.0
   crypto: ^3.0.3
   flutter_cache_manager: ^3.4.0


### PR DESCRIPTION
Update Flutter to Version 3.24.0 and replace the deprecated `background` and `onBackground` colors with `surface` and `onSurface`. Within this migration we also adjusted the `onSecondary` color, so that the apps look as before the update.

<!--
  Keep PR title verbose enough and add prefix telling about what source it touches e.g "[rss] Add feature xyz" or if the
  the PR is not realated to a source use "[core]", e.g. "[core] Fix xyz".

  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
