### PR TITLE
Allow Importing / Exporting of Decks

### DIFF
--- a/app/android/.gitignore
+++ b/app/android/.gitignore
@@ -5,6 +5,7 @@ gradle-wrapper.jar
 /gradlew.bat
 /local.properties
 GeneratedPluginRegistrant.java
+.cxx/
 
 # Remember to never publicly share your keystore.
 # See https://flutter.dev/docs/deployment/android#reference-the-keystore-from-the-app

--- a/app/android/app/build.gradle
+++ b/app/android/app/build.gradle
@@ -85,4 +85,7 @@ flutter {
 
 dependencies {
     implementation 'com.google.android.gms:play-services-auth:20.6.0'
+    // This is required for the "file_picker" Flutter package, because without the app crash when exporting a file with the following error:
+    // "java.lang.NoClassDefFoundError: Failed resolution of: Ljavax/xml/stream/XMLResolver;"
+    implementation 'javax.xml.stream:stax-api:1.0-2'
 }

--- a/app/ios/Podfile
+++ b/app/ios/Podfile
@@ -27,6 +27,9 @@ require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelpe
 
 flutter_ios_podfile_setup
 
+Pod::PICKER_MEDIA = false
+Pod::PICKER_AUDIO = false
+
 target 'Runner' do
   use_frameworks!
   use_modular_headers!

--- a/app/ios/Podfile.lock
+++ b/app/ios/Podfile.lock
@@ -5,6 +5,8 @@ PODS:
     - Flutter
   - audio_session (0.0.1):
     - Flutter
+  - file_picker (0.0.1):
+    - Flutter
   - Flutter (1.0.0)
   - flutter_native_splash (2.4.3):
     - Flutter
@@ -49,6 +51,7 @@ DEPENDENCIES:
   - app_links (from `.symlinks/plugins/app_links/ios`)
   - audio_service (from `.symlinks/plugins/audio_service/ios`)
   - audio_session (from `.symlinks/plugins/audio_session/ios`)
+  - file_picker (from `.symlinks/plugins/file_picker/ios`)
   - Flutter (from `Flutter`)
   - flutter_native_splash (from `.symlinks/plugins/flutter_native_splash/ios`)
   - just_audio (from `.symlinks/plugins/just_audio/darwin`)
@@ -78,6 +81,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/audio_service/ios"
   audio_session:
     :path: ".symlinks/plugins/audio_session/ios"
+  file_picker:
+    :path: ".symlinks/plugins/file_picker/ios"
   Flutter:
     :path: Flutter
   flutter_native_splash:
@@ -115,6 +120,7 @@ SPEC CHECKSUMS:
   app_links: 76b66b60cc809390ca1ad69bfd66b998d2387ac7
   audio_service: 2023a4a1bdb2fd1443e7b00bdbdb1baa321525db
   audio_session: 94075f61f538dbe8f90f0cee58af3f1837ba7d2b
+  file_picker: fb04e739ae6239a76ce1f571863a196a922c87d4
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   flutter_native_splash: c32d145d68aeda5502d5f543ee38c192065986cf
   just_audio: 4e391f57b79cad2b0674030a00453ca5ce817eed
@@ -134,6 +140,6 @@ SPEC CHECKSUMS:
   volume_controller: ca1cde542ee70fad77d388f82e9616488110942b
   wakelock_plus: fd58c82b1388f4afe3fe8aa2c856503a262a5b03
 
-PODFILE CHECKSUM: 0275dfca310618961ca5ac1cb793052f1f5563e7
+PODFILE CHECKSUM: a35dde46ea09af570b675187a949f5fa3bc82280
 
 COCOAPODS: 1.16.2

--- a/app/ios/Runner/Info.plist
+++ b/app/ios/Runner/Info.plist
@@ -68,6 +68,8 @@
 			<string>UIInterfaceOrientationLandscapeRight</string>
 		</array>
 		<key>UIViewControllerBasedStatusBarAppearance</key>
-		<false/>
+    <false/>
+    <key>UISupportsDocumentBrowser</key>
+    <true/>
 	</dict>
 </plist>

--- a/app/lib/models/column.dart
+++ b/app/lib/models/column.dart
@@ -1,3 +1,5 @@
+import 'package:xml/xml.dart';
+
 import 'package:feeddeck/models/source.dart';
 
 /// [FDColumn] is the model for a column in our app. The following fields are
@@ -26,11 +28,12 @@ class FDColumn {
       id: data['id'],
       name: data['name'],
       position: data['position'],
-      sources: data.containsKey('sources') && data['sources'] != null
-          ? List<FDSource>.from(
-              data['sources'].map((source) => FDSource.fromJson(source)),
-            )
-          : [],
+      sources:
+          data.containsKey('sources') && data['sources'] != null
+              ? List<FDSource>.from(
+                data['sources'].map((source) => FDSource.fromJson(source)),
+              )
+              : [],
     );
   }
 
@@ -39,5 +42,35 @@ class FDColumn {
   /// items, when the column is changed (e.g. source is added / deleted).
   String identifier() {
     return 'id: $id, sources: ${sources.map((source) => source.id).join(' ')}';
+  }
+
+  factory FDColumn.fromXml(XmlElement element) {
+    final sources = <FDSource>[];
+
+    element.findElements('outline').forEach((outline) {
+      final source = FDSource.fromXml(outline);
+      if (source.type != FDSourceType.none) {
+        sources.add(source);
+      }
+    });
+
+    return FDColumn(
+      id: '',
+      name: element.getAttribute('text') ?? 'Unknown',
+      position: 0,
+      sources: sources,
+    );
+  }
+
+  void toXml(XmlBuilder builder) {
+    builder.element(
+      'outline',
+      nest: () {
+        builder.attribute('text', name);
+        for (var i = 0; i < sources.length; i++) {
+          sources[i].toXml(builder);
+        }
+      },
+    );
   }
 }

--- a/app/lib/models/source.dart
+++ b/app/lib/models/source.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import 'package:xml/xml.dart';
+
 import 'package:feeddeck/models/sources/github.dart';
 import 'package:feeddeck/models/sources/googlenews.dart';
 import 'package:feeddeck/models/sources/stackoverflow.dart';
@@ -236,20 +238,25 @@ class FDSource {
     required this.icon,
   });
 
+  String get prettyTitle => title.replaceAll(RegExp(r'(?! )\s+| \s+'), ' ');
+
   factory FDSource.fromJson(Map<String, dynamic> data) {
     return FDSource(
       id: data['id'],
       type: getSourceTypeFromString(data['type']),
       title: data['title'],
-      options: data.containsKey('options') && data['options'] != null
-          ? FDSourceOptions.fromJson(data['options'])
-          : null,
-      link: data.containsKey('link') && data['link'] != null
-          ? data['link']
-          : null,
-      icon: data.containsKey('icon') && data['icon'] != null
-          ? data['icon']
-          : null,
+      options:
+          data.containsKey('options') && data['options'] != null
+              ? FDSourceOptions.fromJson(data['options'])
+              : null,
+      link:
+          data.containsKey('link') && data['link'] != null
+              ? data['link']
+              : null,
+      icon:
+          data.containsKey('icon') && data['icon'] != null
+              ? data['icon']
+              : null,
     );
   }
 
@@ -262,6 +269,46 @@ class FDSource {
       'link': link,
       'icon': icon,
     };
+  }
+
+  factory FDSource.fromXml(XmlElement element) {
+    final type = getSourceTypeFromString(element.getAttribute('type') ?? '');
+    final text = element.getAttribute('text');
+
+    if (type == FDSourceType.none || text == null) {
+      return FDSource(
+        id: '',
+        type: FDSourceType.none,
+        title: '',
+        options: null,
+        link: null,
+        icon: null,
+      );
+    }
+
+    return FDSource(
+      id: '',
+      type: type,
+      title: text,
+      options: FDSourceOptions.fromXml(element),
+      link: null,
+      icon: null,
+    );
+  }
+
+  void toXml(XmlBuilder builder) {
+    builder.element(
+      'outline',
+      nest: () {
+        builder.attribute('type', type.toShortString());
+        builder.attribute('text', prettyTitle);
+        builder.attribute('htmlUrl', link);
+
+        if (options != null) {
+          options!.toXml(builder);
+        }
+      },
+    );
   }
 }
 
@@ -302,25 +349,29 @@ class FDSourceOptions {
 
   factory FDSourceOptions.fromJson(Map<String, dynamic> responseData) {
     return FDSourceOptions(
-      fourchan: responseData.containsKey('fourchan') &&
-              responseData['fourchan'] != null
-          ? responseData['fourchan']
-          : null,
+      fourchan:
+          responseData.containsKey('fourchan') &&
+                  responseData['fourchan'] != null
+              ? responseData['fourchan']
+              : null,
       github:
           responseData.containsKey('github') && responseData['github'] != null
               ? FDGitHubOptions.fromJson(responseData['github'])
               : null,
-      googlenews: responseData.containsKey('googlenews') &&
-              responseData['googlenews'] != null
-          ? FDGoogleNewsOptions.fromJson(responseData['googlenews'])
-          : null,
-      lemmy: responseData.containsKey('lemmy') && responseData['lemmy'] != null
-          ? responseData['lemmy']
-          : null,
-      mastodon: responseData.containsKey('mastodon') &&
-              responseData['mastodon'] != null
-          ? responseData['mastodon']
-          : null,
+      googlenews:
+          responseData.containsKey('googlenews') &&
+                  responseData['googlenews'] != null
+              ? FDGoogleNewsOptions.fromJson(responseData['googlenews'])
+              : null,
+      lemmy:
+          responseData.containsKey('lemmy') && responseData['lemmy'] != null
+              ? responseData['lemmy']
+              : null,
+      mastodon:
+          responseData.containsKey('mastodon') &&
+                  responseData['mastodon'] != null
+              ? responseData['mastodon']
+              : null,
       medium:
           responseData.containsKey('medium') && responseData['medium'] != null
               ? responseData['medium']
@@ -329,10 +380,11 @@ class FDSourceOptions {
           responseData.containsKey('nitter') && responseData['nitter'] != null
               ? responseData['nitter']
               : null,
-      pinterest: responseData.containsKey('pinterest') &&
-              responseData['pinterest'] != null
-          ? responseData['pinterest']
-          : null,
+      pinterest:
+          responseData.containsKey('pinterest') &&
+                  responseData['pinterest'] != null
+              ? responseData['pinterest']
+              : null,
       podcast:
           responseData.containsKey('podcast') && responseData['podcast'] != null
               ? responseData['podcast']
@@ -341,13 +393,15 @@ class FDSourceOptions {
           responseData.containsKey('reddit') && responseData['reddit'] != null
               ? responseData['reddit']
               : null,
-      rss: responseData.containsKey('rss') && responseData['rss'] != null
-          ? responseData['rss']
-          : null,
-      stackoverflow: responseData.containsKey('stackoverflow') &&
-              responseData['stackoverflow'] != null
-          ? FDStackOverflowOptions.fromJson(responseData['stackoverflow'])
-          : null,
+      rss:
+          responseData.containsKey('rss') && responseData['rss'] != null
+              ? responseData['rss']
+              : null,
+      stackoverflow:
+          responseData.containsKey('stackoverflow') &&
+                  responseData['stackoverflow'] != null
+              ? FDStackOverflowOptions.fromJson(responseData['stackoverflow'])
+              : null,
       tumblr:
           responseData.containsKey('tumblr') && responseData['tumblr'] != null
               ? responseData['tumblr']
@@ -376,5 +430,56 @@ class FDSourceOptions {
       'tumblr': tumblr,
       'youtube': youtube,
     };
+  }
+
+  factory FDSourceOptions.fromXml(XmlElement element) {
+    return FDSourceOptions(
+      fourchan: element.getAttribute('fourchan'),
+      github: FDGitHubOptions.fromXml(element),
+      googlenews: FDGoogleNewsOptions.fromXml(element),
+      lemmy: element.getAttribute('lemmy'),
+      mastodon: element.getAttribute('mastodon'),
+      medium: element.getAttribute('medium'),
+      nitter: element.getAttribute('nitter'),
+      pinterest: element.getAttribute('pinterest'),
+      podcast: element.getAttribute('podcast'),
+      reddit: element.getAttribute('reddit'),
+      rss: element.getAttribute('xmlUrl'),
+      stackoverflow: FDStackOverflowOptions.fromXml(element),
+      tumblr: element.getAttribute('tumblr'),
+      youtube: element.getAttribute('youtube'),
+    );
+  }
+
+  void toXml(XmlBuilder builder) {
+    if (fourchan != null) {
+      builder.attribute('fourchan', fourchan);
+    } else if (github != null) {
+      github!.toXml(builder);
+    } else if (googlenews != null) {
+      googlenews!.toXml(builder);
+    } else if (lemmy != null) {
+      builder.attribute('lemmy', lemmy);
+    } else if (mastodon != null) {
+      builder.attribute('mastodon', mastodon);
+    } else if (medium != null) {
+      builder.attribute('medium', medium);
+    } else if (nitter != null) {
+      builder.attribute('nitter', nitter);
+    } else if (pinterest != null) {
+      builder.attribute('pinterest', pinterest);
+    } else if (podcast != null) {
+      builder.attribute('podcast', podcast);
+    } else if (reddit != null) {
+      builder.attribute('reddit', reddit);
+    } else if (rss != null) {
+      builder.attribute('xmlUrl', rss);
+    } else if (stackoverflow != null) {
+      stackoverflow!.toXml(builder);
+    } else if (tumblr != null) {
+      builder.attribute('tumblr', tumblr);
+    } else if (youtube != null) {
+      builder.attribute('youtube', youtube);
+    }
   }
 }

--- a/app/lib/models/sources/github.dart
+++ b/app/lib/models/sources/github.dart
@@ -1,3 +1,5 @@
+import 'package:xml/xml.dart';
+
 /// [FDGitHubType] is an enum value which defines the type for the GitHub
 /// source.
 enum FDGitHubType {
@@ -88,31 +90,38 @@ class FDGitHubOptions {
 
   factory FDGitHubOptions.fromJson(Map<String, dynamic> responseData) {
     return FDGitHubOptions(
-      type: responseData.containsKey('type') && responseData['type'] != null
-          ? getGitHubTypeFromString(responseData['type'])
-          : null,
-      participating: responseData.containsKey('participating') &&
-              responseData['participating'] != null
-          ? responseData['participating']
-          : null,
-      repository: responseData.containsKey('repository') &&
-              responseData['repository'] != null
-          ? responseData['repository']
-          : null,
-      user: responseData.containsKey('user') && responseData['user'] != null
-          ? responseData['user']
-          : null,
-      organization: responseData.containsKey('organization') &&
-              responseData['organization'] != null
-          ? responseData['organization']
-          : null,
-      queryName: responseData.containsKey('queryName') &&
-              responseData['queryName'] != null
-          ? responseData['queryName']
-          : null,
-      query: responseData.containsKey('query') && responseData['query'] != null
-          ? responseData['query']
-          : null,
+      type:
+          responseData.containsKey('type') && responseData['type'] != null
+              ? getGitHubTypeFromString(responseData['type'])
+              : null,
+      participating:
+          responseData.containsKey('participating') &&
+                  responseData['participating'] != null
+              ? responseData['participating']
+              : null,
+      repository:
+          responseData.containsKey('repository') &&
+                  responseData['repository'] != null
+              ? responseData['repository']
+              : null,
+      user:
+          responseData.containsKey('user') && responseData['user'] != null
+              ? responseData['user']
+              : null,
+      organization:
+          responseData.containsKey('organization') &&
+                  responseData['organization'] != null
+              ? responseData['organization']
+              : null,
+      queryName:
+          responseData.containsKey('queryName') &&
+                  responseData['queryName'] != null
+              ? responseData['queryName']
+              : null,
+      query:
+          responseData.containsKey('query') && responseData['query'] != null
+              ? responseData['query']
+              : null,
     );
   }
 
@@ -126,5 +135,41 @@ class FDGitHubOptions {
       'queryName': queryName,
       'query': query,
     };
+  }
+
+  factory FDGitHubOptions.fromXml(XmlElement element) {
+    return FDGitHubOptions(
+      type: getGitHubTypeFromString(element.getAttribute('githubType') ?? ''),
+      participating: element.getAttribute('githubParticipating') == 'true',
+      repository: element.getAttribute('githubRepository'),
+      user: element.getAttribute('githubUser'),
+      organization: element.getAttribute('githubOrganization'),
+      queryName: element.getAttribute('githubQueryName'),
+      query: element.getAttribute('githubQuery'),
+    );
+  }
+
+  void toXml(XmlBuilder builder) {
+    if (type != null) {
+      builder.attribute('githubType', type!.toShortString());
+    }
+    if (participating != null) {
+      builder.attribute('githubParticipating', participating);
+    }
+    if (repository != null) {
+      builder.attribute('githubRepository', repository);
+    }
+    if (user != null) {
+      builder.attribute('githubUser', user);
+    }
+    if (organization != null) {
+      builder.attribute('githubOrganization', organization);
+    }
+    if (queryName != null) {
+      builder.attribute('githubQueryName', queryName);
+    }
+    if (query != null) {
+      builder.attribute('githubQuery', query);
+    }
   }
 }

--- a/app/lib/models/sources/googlenews.dart
+++ b/app/lib/models/sources/googlenews.dart
@@ -1,9 +1,8 @@
+import 'package:xml/xml.dart';
+
 /// [FDGoogleNewsType] is an enum value which defines the type for the Google
 /// News source.
-enum FDGoogleNewsType {
-  url,
-  search,
-}
+enum FDGoogleNewsType { url, search }
 
 /// [FDGoogleNewsTypeExtension] defines all extensions which are available for
 /// the [FDGoogleNewsType] enum type.
@@ -61,25 +60,30 @@ class FDGoogleNewsOptions {
 
   factory FDGoogleNewsOptions.fromJson(Map<String, dynamic> responseData) {
     return FDGoogleNewsOptions(
-      type: responseData.containsKey('type') && responseData['type'] != null
-          ? getGoogleNewsTypeFromString(responseData['type'])
-          : null,
-      url: responseData.containsKey('url') && responseData['url'] != null
-          ? responseData['url']
-          : null,
+      type:
+          responseData.containsKey('type') && responseData['type'] != null
+              ? getGoogleNewsTypeFromString(responseData['type'])
+              : null,
+      url:
+          responseData.containsKey('url') && responseData['url'] != null
+              ? responseData['url']
+              : null,
       search:
           responseData.containsKey('search') && responseData['search'] != null
               ? responseData['search']
               : null,
-      ceid: responseData.containsKey('ceid') && responseData['ceid'] != null
-          ? responseData['ceid']
-          : null,
-      gl: responseData.containsKey('gl') && responseData['gl'] != null
-          ? responseData['gl']
-          : null,
-      hl: responseData.containsKey('hl') && responseData['hl'] != null
-          ? responseData['hl']
-          : null,
+      ceid:
+          responseData.containsKey('ceid') && responseData['ceid'] != null
+              ? responseData['ceid']
+              : null,
+      gl:
+          responseData.containsKey('gl') && responseData['gl'] != null
+              ? responseData['gl']
+              : null,
+      hl:
+          responseData.containsKey('hl') && responseData['hl'] != null
+              ? responseData['hl']
+              : null,
     );
   }
 
@@ -92,5 +96,39 @@ class FDGoogleNewsOptions {
       'gl': gl,
       'hl': hl,
     };
+  }
+
+  factory FDGoogleNewsOptions.fromXml(XmlElement element) {
+    return FDGoogleNewsOptions(
+      type: getGoogleNewsTypeFromString(
+        element.getAttribute('googlenewsType') ?? '',
+      ),
+      url: element.getAttribute('googlenewsUrl'),
+      search: element.getAttribute('googlenewsSearch'),
+      ceid: element.getAttribute('googlenewsCeid'),
+      gl: element.getAttribute('googlenewsGl'),
+      hl: element.getAttribute('googlenewsHl'),
+    );
+  }
+
+  void toXml(XmlBuilder builder) {
+    if (type != null) {
+      builder.attribute('googlenewsType', type!.toShortString());
+    }
+    if (url != null) {
+      builder.attribute('googlenewsUrl', url);
+    }
+    if (search != null) {
+      builder.attribute('googlenewsSearch', search);
+    }
+    if (ceid != null) {
+      builder.attribute('googlenewsCeid', ceid);
+    }
+    if (gl != null) {
+      builder.attribute('googlenewsGl', gl);
+    }
+    if (hl != null) {
+      builder.attribute('googlenewsHl', hl);
+    }
   }
 }

--- a/app/lib/models/sources/stackoverflow.dart
+++ b/app/lib/models/sources/stackoverflow.dart
@@ -1,9 +1,8 @@
+import 'package:xml/xml.dart';
+
 /// [FDStackOverflowType] is an enum value which defines the type for the
 /// StackOverflow source.
-enum FDStackOverflowType {
-  url,
-  tag,
-}
+enum FDStackOverflowType { url, tag }
 
 /// [FDStackOverflowTypeExtension] defines all extensions which are available for
 /// the [FDStackOverflowType] enum type.
@@ -42,12 +41,7 @@ FDStackOverflowType getStackOverflowTypeFromString(String state) {
 
 /// [FDStackOverflowSort] is an enum value which defines the available sort
 /// properties for the [FDStackOverflowOptions]
-enum FDStackOverflowSort {
-  newest,
-  active,
-  featured,
-  votes,
-}
+enum FDStackOverflowSort { newest, active, featured, votes }
 
 /// [FDStackOverflowSortExtension] defines all extensions which are available
 /// for the [FDStackOverflowSort] enum type.
@@ -100,27 +94,26 @@ class FDStackOverflowOptions {
   String? tag;
   FDStackOverflowSort? sort;
 
-  FDStackOverflowOptions({
-    this.type,
-    this.url,
-    this.tag,
-    this.sort,
-  });
+  FDStackOverflowOptions({this.type, this.url, this.tag, this.sort});
 
   factory FDStackOverflowOptions.fromJson(Map<String, dynamic> responseData) {
     return FDStackOverflowOptions(
-      type: responseData.containsKey('type') && responseData['type'] != null
-          ? getStackOverflowTypeFromString(responseData['type'])
-          : null,
-      url: responseData.containsKey('url') && responseData['url'] != null
-          ? responseData['url']
-          : null,
-      tag: responseData.containsKey('tag') && responseData['tag'] != null
-          ? responseData['tag']
-          : null,
-      sort: responseData.containsKey('sort') && responseData['sort'] != null
-          ? getStackOverflowSortFromString(responseData['sort'])
-          : null,
+      type:
+          responseData.containsKey('type') && responseData['type'] != null
+              ? getStackOverflowTypeFromString(responseData['type'])
+              : null,
+      url:
+          responseData.containsKey('url') && responseData['url'] != null
+              ? responseData['url']
+              : null,
+      tag:
+          responseData.containsKey('tag') && responseData['tag'] != null
+              ? responseData['tag']
+              : null,
+      sort:
+          responseData.containsKey('sort') && responseData['sort'] != null
+              ? getStackOverflowSortFromString(responseData['sort'])
+              : null,
     );
   }
 
@@ -131,5 +124,33 @@ class FDStackOverflowOptions {
       'tag': tag,
       'sort': sort?.toShortString(),
     };
+  }
+
+  factory FDStackOverflowOptions.fromXml(XmlElement element) {
+    return FDStackOverflowOptions(
+      type: getStackOverflowTypeFromString(
+        element.getAttribute('stackoverflowType') ?? '',
+      ),
+      url: element.getAttribute('stackoverflowUrl'),
+      tag: element.getAttribute('stackoverflowTag'),
+      sort: getStackOverflowSortFromString(
+        element.getAttribute('stackoverflowSort') ?? '',
+      ),
+    );
+  }
+
+  void toXml(XmlBuilder builder) {
+    if (type != null) {
+      builder.attribute('stackoverflowType', type!.toShortString());
+    }
+    if (url != null) {
+      builder.attribute('stackoverflowUrl', url);
+    }
+    if (tag != null) {
+      builder.attribute('stackoverflowTag', tag);
+    }
+    if (sort != null) {
+      builder.attribute('stackoverflowSort', sort);
+    }
   }
 }

--- a/app/lib/repositories/app_repository.dart
+++ b/app/lib/repositories/app_repository.dart
@@ -168,6 +168,19 @@ class AppRepository with ChangeNotifier {
     return List<FDDeck>.from(data.map((deck) => FDDeck.fromJson(deck)));
   }
 
+  /// [getDecksWithNotifiy] uses the [getDecks] function to get a list of all
+  /// decks for the user, but instead of returning the decks it updates the
+  /// [_decks] property and calls all the registered listeners.
+  ///
+  /// This function can be used to trigger an update of the decks when they are
+  /// created outside of the AppRepository, like it is done in the import
+  /// process.
+  Future<void> getDecksWithNotifiy() async {
+    final decks = await getDecks();
+    _decks = decks;
+    notifyListeners();
+  }
+
   /// [updateDeck] is called to update a deck for the user. The function takes
   /// a [deckId] and a [name] as parameters. The function calls the Supabase
   /// client to update the name of the deck. After the deck was updated, the

--- a/app/lib/widgets/item/details/utils/item_piped/item_piped_video_web.dart
+++ b/app/lib/widgets/item/details/utils/item_piped/item_piped_video_web.dart
@@ -1,8 +1,8 @@
-import 'package:web/web.dart';
-
 import 'dart:ui' as ui;
 
 import 'package:flutter/material.dart';
+
+import 'package:web/web.dart';
 
 import 'package:feeddeck/utils/constants.dart';
 import 'item_piped_video.dart';

--- a/app/lib/widgets/item/details/utils/item_youtube/item_youtube_video_web.dart
+++ b/app/lib/widgets/item/details/utils/item_youtube/item_youtube_video_web.dart
@@ -1,8 +1,8 @@
-import 'package:web/web.dart';
-
 import 'dart:ui' as ui;
 
 import 'package:flutter/material.dart';
+
+import 'package:web/web.dart';
 
 import 'package:feeddeck/utils/constants.dart';
 import 'item_youtube_video.dart';

--- a/app/lib/widgets/settings/app_settings/app_settings.dart
+++ b/app/lib/widgets/settings/app_settings/app_settings.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+
+import 'package:feeddeck/utils/constants.dart';
+import 'package:feeddeck/widgets/settings/app_settings/app_settings_export.dart';
+import 'package:feeddeck/widgets/settings/app_settings/app_settings_import.dart';
+
+/// The [SettSettingsAppSettings] widget is used to display a list of all
+/// available app settings, which can be used to customize the app by the user
+/// and to import and export data.
+class SettingsAppSettings extends StatelessWidget {
+  const SettingsAppSettings({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'App Settings',
+          style: TextStyle(fontSize: 20.0, fontWeight: FontWeight.bold),
+        ),
+        SizedBox(height: Constants.spacingSmall),
+        SettingsAppSettingsExport(),
+        SettingsAppSettingsImport(),
+        SizedBox(height: Constants.spacingMiddle),
+      ],
+    );
+  }
+}

--- a/app/lib/widgets/settings/app_settings/app_settings_export.dart
+++ b/app/lib/widgets/settings/app_settings/app_settings_export.dart
@@ -1,0 +1,356 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+import 'package:file_picker/file_picker.dart';
+import 'package:provider/provider.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:xml/xml.dart';
+
+import 'package:feeddeck/models/column.dart';
+import 'package:feeddeck/models/deck.dart';
+import 'package:feeddeck/models/source.dart';
+import 'package:feeddeck/repositories/app_repository.dart';
+import 'package:feeddeck/utils/constants.dart';
+import 'package:feeddeck/widgets/general/elevated_button_progress_indicator.dart';
+
+class SettingsAppSettingsExport extends StatelessWidget {
+  const SettingsAppSettingsExport({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MouseRegion(
+      cursor: SystemMouseCursors.click,
+      child: GestureDetector(
+        onTap: () {
+          showModalBottomSheet(
+            context: context,
+            isScrollControlled: true,
+            isDismissible: true,
+            useSafeArea: true,
+            backgroundColor: Colors.transparent,
+            shape: const RoundedRectangleBorder(
+              borderRadius: BorderRadius.vertical(
+                top: Radius.circular(Constants.spacingMiddle),
+              ),
+            ),
+            clipBehavior: Clip.antiAliasWithSaveLayer,
+            constraints: const BoxConstraints(
+              maxWidth: Constants.centeredFormMaxWidth,
+            ),
+            builder: (BuildContext context) {
+              return Export();
+            },
+          );
+        },
+        child: Card(
+          color: Constants.secondary,
+          margin: const EdgeInsets.only(bottom: Constants.spacingSmall),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(12),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Padding(
+                padding: const EdgeInsets.all(Constants.spacingMiddle),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            Characters('Export')
+                                .replaceAll(
+                                  Characters(''),
+                                  Characters('\u{200B}'),
+                                )
+                                .toString(),
+                            maxLines: 1,
+                            style: const TextStyle(
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                    Icon(Icons.download),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class Export extends StatefulWidget {
+  const Export({super.key});
+
+  @override
+  State<Export> createState() => _ExportState();
+}
+
+class _ExportState extends State<Export> {
+  FDDeck? _selectedDeck;
+  bool _isLoading = false;
+  String _success = '';
+  String _error = '';
+
+  /// [_export] is the function to export a deck as OPML file. In the first step
+  /// we have to get the columns for the selected deck and all sources for all
+  /// the columns of the deck. Afterwards we create the OPML file and save it.
+  Future<void> _export() async {
+    setState(() {
+      _isLoading = true;
+      _success = '';
+      _error = '';
+    });
+
+    /// If the [_selectedDeckId] is an empty string the user didn't selected a
+    /// deck which should be exported, so that we return an error.
+    if (_selectedDeck == null) {
+      setState(() {
+        _error = 'Please select a deck to export.';
+        _isLoading = false;
+      });
+      return;
+    }
+
+    try {
+      /// Get all the columns for the [_selectedDeckId].
+      final data = await Supabase.instance.client
+          .from('columns')
+          .select('id, name, position')
+          .eq('deckId', _selectedDeck!.id)
+          .order('position', ascending: true);
+      final columns = List<FDColumn>.from(
+        data.map((column) => FDColumn.fromJson(column)),
+      );
+
+      /// Loop through all the columns and get the sources for each column. The
+      /// sources are then added to the `sources` field of the column.
+      for (var i = 0; i < columns.length; i++) {
+        final data = await Supabase.instance.client
+            .from('sources')
+            .select('id, type, title, options, link, icon')
+            .eq('columnId', columns[i].id)
+            .order('position', ascending: true, nullsFirst: false)
+            .order('createdAt', ascending: true);
+        columns[i].sources = List<FDSource>.from(
+          data.map((source) => FDSource.fromJson(source)),
+        );
+      }
+
+      /// Build the OPML file. Here we only add the `opml` tag with the `head`
+      /// and `body` tags. The `head` tag contains the deck name within the
+      /// `title` tag. To fill the body we go through all columns to create a
+      /// `outline` tag for each column and a nested `outline` tag for each
+      /// souce. This is handled by the [toXml] methhod of the corresponding
+      /// models.
+      var builder = XmlBuilder();
+      builder.processing('xml', 'version="1.0" encoding="utf-8"');
+      builder.element(
+        'opml',
+        nest: () {
+          builder.attribute('version', '2.0');
+          builder.element(
+            'head',
+            nest: () {
+              builder.element(
+                'title',
+                nest: () {
+                  builder.text(_selectedDeck!.name);
+                },
+              );
+            },
+          );
+          builder.element(
+            'body',
+            nest: () {
+              for (var i = 0; i < columns.length; i++) {
+                columns[i].toXml(builder);
+              }
+            },
+          );
+        },
+      );
+      final opml = builder.buildDocument().toXmlString(pretty: true);
+
+      /// On native platforms the file name should not contain the extension,
+      /// otherwise the extension is added twice. On the web the file name must
+      /// contain the extension.
+      String fileName = 'feeddeck-export-${_selectedDeck!.id}';
+      if (kIsWeb) {
+        fileName = 'feeddeck-export-${_selectedDeck!.id}.opml';
+      }
+
+      /// Open a file picker to let the user save the OPML file. When the file
+      /// is saved successfully the file picker will return the file path on
+      /// native platforms. If the file path is `null` the user aborted the
+      /// export. On the web the file path will always be empty, so that we can
+      /// directly display a [_success] message.
+      final filePath = await FilePicker.platform.saveFile(
+        allowedExtensions: ['opml'],
+        type: FileType.custom,
+        dialogTitle: 'Export',
+        fileName: fileName,
+        lockParentWindow: true,
+        bytes: utf8.encode(opml),
+      );
+
+      if (kIsWeb) {
+        setState(() {
+          _success = 'Export successful';
+          _isLoading = false;
+        });
+        return;
+      }
+
+      if (filePath == null) {
+        setState(() {
+          _isLoading = false;
+        });
+        return;
+      }
+
+      setState(() {
+        _success = 'Export successful: $filePath';
+        _isLoading = false;
+      });
+    } catch (err) {
+      setState(() {
+        _error = 'Export failed: ${err.toString()}';
+        _isLoading = false;
+      });
+    }
+  }
+
+  /// [_buildSuccess] returns a widget to display the [_success] when it is not
+  /// an empty string.
+  Widget _buildSuccess() {
+    if (_success != '') {
+      return Padding(
+        padding: const EdgeInsets.all(Constants.spacingMiddle),
+        child: Text(_success, style: const TextStyle(color: Constants.primary)),
+      );
+    }
+
+    return Container();
+  }
+
+  /// [_buildError] returns a widget to display the [_error] when it is not an
+  /// empty string.
+  Widget _buildError() {
+    if (_error != '') {
+      return Padding(
+        padding: const EdgeInsets.all(Constants.spacingMiddle),
+        child: Text(_error, style: const TextStyle(color: Constants.error)),
+      );
+    }
+
+    return Container();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    AppRepository app = Provider.of<AppRepository>(context, listen: true);
+
+    return Scaffold(
+      appBar: AppBar(
+        automaticallyImplyLeading: false,
+        shape: const Border(
+          bottom: BorderSide(color: Constants.dividerColor, width: 1),
+        ),
+        title: Text('Export'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.close),
+            onPressed: () {
+              Navigator.of(context).pop();
+            },
+          ),
+        ],
+      ),
+      body: SafeArea(
+        child: Column(
+          children: [
+            Expanded(
+              child: Padding(
+                padding: const EdgeInsets.all(Constants.spacingMiddle),
+                child: SingleChildScrollView(
+                  child: Column(
+                    children: [
+                      Text(
+                        'Select a deck, which should be exported from the following list. Click the "Export" button afterwards to save the deck as OPML file.',
+                      ),
+                      const SizedBox(height: Constants.spacingMiddle),
+                      ListView.builder(
+                        shrinkWrap: true,
+                        physics: const NeverScrollableScrollPhysics(),
+                        itemCount: app.decks.length,
+                        itemBuilder: (context, index) {
+                          return RadioListTile(
+                            title: Text(app.decks[index].name),
+                            dense: true,
+                            visualDensity: const VisualDensity(
+                              horizontal: VisualDensity.minimumDensity,
+                              vertical: VisualDensity.minimumDensity,
+                            ),
+                            value: app.decks[index].id,
+                            groupValue: _selectedDeck?.id,
+                            onChanged: (String? deckId) {
+                              if (deckId != null) {
+                                setState(() {
+                                  _selectedDeck = app.decks[index];
+                                });
+                              }
+                            },
+                          );
+                        },
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+            const SizedBox(height: Constants.spacingSmall),
+            const Divider(
+              color: Constants.dividerColor,
+              height: 1,
+              thickness: 1,
+            ),
+            _buildSuccess(),
+            _buildError(),
+            Padding(
+              padding: const EdgeInsets.all(Constants.spacingMiddle),
+              child: ElevatedButton.icon(
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: Constants.secondary,
+                  foregroundColor: Constants.onSecondary,
+                  maximumSize: const Size.fromHeight(
+                    Constants.elevatedButtonSize,
+                  ),
+                  minimumSize: const Size.fromHeight(
+                    Constants.elevatedButtonSize,
+                  ),
+                ),
+                label: const Text('Export'),
+                onPressed: _isLoading ? null : _export,
+                icon:
+                    _isLoading
+                        ? const ElevatedButtonProgressIndicator()
+                        : const Icon(Icons.download),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/widgets/settings/app_settings/app_settings_import.dart
+++ b/app/lib/widgets/settings/app_settings/app_settings_import.dart
@@ -1,0 +1,435 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+import 'package:file_picker/file_picker.dart';
+import 'package:provider/provider.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:xml/xml.dart';
+
+import 'package:feeddeck/models/column.dart';
+import 'package:feeddeck/models/deck.dart';
+import 'package:feeddeck/models/source.dart';
+import 'package:feeddeck/repositories/app_repository.dart';
+import 'package:feeddeck/utils/constants.dart';
+import 'package:feeddeck/widgets/general/elevated_button_progress_indicator.dart';
+
+class SettingsAppSettingsImport extends StatelessWidget {
+  const SettingsAppSettingsImport({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MouseRegion(
+      cursor: SystemMouseCursors.click,
+      child: GestureDetector(
+        onTap: () {
+          showModalBottomSheet(
+            context: context,
+            isScrollControlled: true,
+            isDismissible: true,
+            useSafeArea: true,
+            backgroundColor: Colors.transparent,
+            shape: const RoundedRectangleBorder(
+              borderRadius: BorderRadius.vertical(
+                top: Radius.circular(Constants.spacingMiddle),
+              ),
+            ),
+            clipBehavior: Clip.antiAliasWithSaveLayer,
+            constraints: const BoxConstraints(
+              maxWidth: Constants.centeredFormMaxWidth,
+            ),
+            builder: (BuildContext context) {
+              return Import();
+            },
+          );
+        },
+        child: Card(
+          color: Constants.secondary,
+          margin: const EdgeInsets.only(bottom: Constants.spacingSmall),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(12),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Padding(
+                padding: const EdgeInsets.all(Constants.spacingMiddle),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            Characters('Import')
+                                .replaceAll(
+                                  Characters(''),
+                                  Characters('\u{200B}'),
+                                )
+                                .toString(),
+                            maxLines: 1,
+                            style: const TextStyle(
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                    Icon(Icons.upload),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class Import extends StatefulWidget {
+  const Import({super.key});
+
+  @override
+  State<Import> createState() => _ExportState();
+}
+
+class _ExportState extends State<Import> {
+  bool _isLoading = false;
+  String _success = '';
+  String _error = '';
+  int _progressMax = 0;
+  int _progressCurrent = 0;
+
+  /// [_import] is the function to import a deck from a OPML file. In the first
+  /// step we let the user select a file. Then we parse the file and create a
+  /// new deck with all it's columns and sources.
+  Future<void> _import() async {
+    setState(() {
+      _isLoading = true;
+      _success = '';
+      _error = '';
+      _progressMax = 0;
+      _progressCurrent = 0;
+    });
+
+    try {
+      /// Show a file picker, where the user can select an OPML file, which will
+      /// be parsed in the following.
+      ///
+      ///   - For Android we have to unset the [allowedExtensions] and [type],
+      ///     because of https://github.com/miguelpruivo/flutter_file_picker/issues/1689
+      ///   - For iOS we have to unset the [allowedExtensions] and [type],
+      ///     otherwise we can not select files in the file browser.
+      final files =
+          (await FilePicker.platform.pickFiles(
+            allowedExtensions:
+                !kIsWeb && (Platform.isAndroid || Platform.isIOS)
+                    ? null
+                    : ['opml'],
+            type:
+                !kIsWeb && (Platform.isAndroid || Platform.isIOS)
+                    ? FileType.any
+                    : FileType.custom,
+            allowMultiple: false,
+            dialogTitle: 'Import',
+            lockParentWindow: true,
+            withData: true,
+          ))?.files;
+
+      /// If the list of selected files is empty or doesn't has a length of 1 or
+      /// the selected file is empty we return here. This can happen if the user
+      /// aborted the import and closed the file picker without selecting a
+      /// file.
+      if (files == null || files.length != 1 || files[0].bytes == null) {
+        setState(() {
+          _isLoading = false;
+        });
+        return;
+      }
+
+      /// Parse the selected OPML file and get the name of the deck which should
+      /// be created and all the columns and sources.
+      final opml = XmlDocument.parse(utf8.decode(files[0].bytes!));
+
+      final deckName =
+          opml
+              .getElement('opml')
+              ?.getElement('head')
+              ?.getElement('title')
+              ?.innerText ??
+          'Unknown';
+
+      final columns = <FDColumn>[];
+      final unknownColumn = FDColumn(
+        id: '',
+        name: 'Unknown',
+        position: 0,
+        sources: [],
+      );
+
+      opml
+          .getElement('opml')
+          ?.getElement('body')
+          ?.findElements('outline')
+          .forEach((outline) {
+            /// If the `outline` element contains a `type` attribute, it must be
+            /// a source. This can happen if an OPML file from another RSS
+            /// reader is imported, which doesn't categorize the RSS feed.
+            ///
+            /// In this case we try to parse the `outline` element as source and
+            /// add the source to the [unknownColumn] column.
+            if (outline.getAttribute('type') != null) {
+              final source = FDSource.fromXml(outline);
+              if (source.type != FDSourceType.none) {
+                unknownColumn.sources.add(source);
+              }
+              return;
+            }
+
+            /// If the `outline` element doesn't contain a `type` attribute, it
+            /// must be a column. This is the case for all exports from FeedDeck
+            /// and for OPML files from other vendors, which categorize their
+            /// feeds.
+            ///
+            /// In this case we parse the `outline` element as column and add it
+            /// to the [columns]. Within the column parsing we also try to parse
+            /// all sibling `outline` elements as source and add it to the
+            /// column.
+            final column = FDColumn.fromXml(outline);
+            columns.add(column);
+            return;
+          });
+
+      /// If we have added sources to the [unknownColumn] column, we add it to
+      /// the list of [columns]. Otherwise we can ignore it.
+      if (unknownColumn.sources.isNotEmpty) {
+        columns.add(unknownColumn);
+      }
+
+      setState(() {
+        _progressMax = columns
+            .map((column) => column.sources.length)
+            .reduce((a, b) => a + b);
+      });
+
+      /// Create a new deck with the name ([deckName]) we retrieved earlier from
+      /// the selected OPML file.
+      final newDeck = FDDeck.fromJson(
+        await Supabase.instance.client
+            .from('decks')
+            .insert({
+              'name': deckName,
+              'userId': Supabase.instance.client.auth.currentUser!.id,
+            })
+            .select()
+            .single(),
+      );
+
+      final errors = <String>[];
+
+      /// Go through all the columns and sources we got from the OPML file and
+      /// create them in the newly created deck. If this process throws an error
+      /// we do not abort the import, instead we add the error to the list of
+      /// [errors].
+      for (var i = 0; i < columns.length; i++) {
+        try {
+          final newColumn = FDColumn.fromJson(
+            await Supabase.instance.client
+                .from('columns')
+                .insert({
+                  'deckId': newDeck.id,
+                  'userId': Supabase.instance.client.auth.currentUser!.id,
+                  'name': columns[i].name,
+                  'position': i,
+                })
+                .select()
+                .single(),
+          );
+
+          for (var j = 0; j < columns[i].sources.length; j++) {
+            try {
+              final result = await Supabase.instance.client.functions.invoke(
+                'add-or-update-source-v1',
+                body: {
+                  'source': {
+                    'id': '',
+                    'columnId': newColumn.id,
+                    'userId': '',
+                    'type': columns[i].sources[j].type.toShortString(),
+                    'title': '',
+                    'options': columns[i].sources[j].options?.toJson(),
+                  },
+                },
+              );
+
+              if (result.status != 200) {
+                errors.add('Failed to create source: ${result.data['error']}');
+              }
+            } catch (err) {
+              errors.add('Failed to create source: ${err.toString()}');
+            } finally {
+              setState(() {
+                _progressCurrent++;
+              });
+            }
+          }
+        } catch (err) {
+          errors.add('Failed to create column: ${err.toString()}');
+        }
+      }
+
+      /// When we have created the new deck with all it's columns and sources,
+      /// we trigger an update of the decks in the [AppRepository] so that the
+      /// new deck is also visible in the UI.
+      if (mounted) {
+        await Provider.of<AppRepository>(
+          context,
+          listen: false,
+        ).getDecksWithNotifiy();
+      }
+
+      /// While creating all columns and sources we add the errors to the
+      /// [errors] list. If the list is empty everthing went fine. If the list
+      /// contains an error we show the error to the user.
+      if (errors.isNotEmpty) {
+        setState(() {
+          _success = 'Import successfull, with ${errors.length} errors';
+          _isLoading = false;
+        });
+        return;
+      }
+
+      setState(() {
+        _success = 'Import successfull';
+        _isLoading = false;
+      });
+    } catch (err) {
+      setState(() {
+        _error = 'Import failed: ${err.toString()}';
+        _isLoading = false;
+      });
+    }
+  }
+
+  /// [_buildSuccess] returns a widget to display the [_success] when it is not
+  /// an empty string.
+  Widget _buildSuccess() {
+    if (_success != '') {
+      return Padding(
+        padding: const EdgeInsets.all(Constants.spacingMiddle),
+        child: Text(_success, style: const TextStyle(color: Constants.primary)),
+      );
+    }
+
+    return Container();
+  }
+
+  /// [_buildError] returns a widget to display the [_error] when it is not an
+  /// empty string.
+  Widget _buildError() {
+    if (_error != '') {
+      return Padding(
+        padding: const EdgeInsets.all(Constants.spacingMiddle),
+        child: Text(_error, style: const TextStyle(color: Constants.error)),
+      );
+    }
+
+    return Container();
+  }
+
+  /// [_buildProgress] returns a widget to display the progress when the
+  /// [_progressMax] value if not 0.
+  Widget _buildProgress() {
+    if (_progressMax > 0) {
+      return Column(
+        mainAxisAlignment: MainAxisAlignment.start,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Importing source $_progressCurrent of $_progressMax',
+            style: const TextStyle(color: Constants.primary),
+          ),
+          LinearProgressIndicator(value: _progressCurrent / _progressMax),
+        ],
+      );
+    }
+
+    return Container();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        automaticallyImplyLeading: false,
+        shape: const Border(
+          bottom: BorderSide(color: Constants.dividerColor, width: 1),
+        ),
+        title: Text('Import'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.close),
+            onPressed: () {
+              Navigator.of(context).pop();
+            },
+          ),
+        ],
+      ),
+      body: SafeArea(
+        child: Column(
+          children: [
+            Expanded(
+              child: Padding(
+                padding: const EdgeInsets.all(Constants.spacingMiddle),
+                child: SingleChildScrollView(
+                  child: Column(
+                    children: [
+                      Text(
+                        'Click the "Import" button to select an OPML file. This action will create a new deck containing all the columns and sources from the OPML file.',
+                      ),
+                      const SizedBox(height: Constants.spacingMiddle),
+                      _buildProgress(),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+            const SizedBox(height: Constants.spacingSmall),
+            const Divider(
+              color: Constants.dividerColor,
+              height: 1,
+              thickness: 1,
+            ),
+            _buildSuccess(),
+            _buildError(),
+            Padding(
+              padding: const EdgeInsets.all(Constants.spacingMiddle),
+              child: ElevatedButton.icon(
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: Constants.secondary,
+                  foregroundColor: Constants.onSecondary,
+                  maximumSize: const Size.fromHeight(
+                    Constants.elevatedButtonSize,
+                  ),
+                  minimumSize: const Size.fromHeight(
+                    Constants.elevatedButtonSize,
+                  ),
+                ),
+                label: const Text('Import'),
+                onPressed: _isLoading ? null : _import,
+                icon:
+                    _isLoading
+                        ? const ElevatedButtonProgressIndicator()
+                        : const Icon(Icons.upload),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/widgets/settings/settings.dart
+++ b/app/lib/widgets/settings/settings.dart
@@ -5,6 +5,7 @@ import 'package:provider/provider.dart';
 import 'package:feeddeck/repositories/profile_repository.dart';
 import 'package:feeddeck/utils/constants.dart';
 import 'package:feeddeck/widgets/settings/accounts/settings_accounts.dart';
+import 'package:feeddeck/widgets/settings/app_settings/app_settings.dart';
 import 'package:feeddeck/widgets/settings/decks/settings_decks.dart';
 import 'package:feeddeck/widgets/settings/premium/settings_premium.dart';
 import 'package:feeddeck/widgets/settings/profile/settings_profile.dart';
@@ -30,9 +31,10 @@ class _SettingsState extends State<Settings> {
     /// call the function multiple times we set the `force` parameter to
     /// `false`.
     WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
-      Provider.of<ProfileRepository>(context, listen: false)
-          .init(false)
-          .then((_) => {});
+      Provider.of<ProfileRepository>(
+        context,
+        listen: false,
+      ).init(false).then((_) => {});
     });
   }
 
@@ -42,18 +44,14 @@ class _SettingsState extends State<Settings> {
       color: Constants.surface,
       child: SafeArea(
         child: Scaffold(
-          appBar: AppBar(
-            title: const Text('Settings'),
-          ),
+          appBar: AppBar(title: const Text('Settings')),
           body: SingleChildScrollView(
             child: Center(
               child: Container(
                 constraints: const BoxConstraints(
                   maxWidth: Constants.centeredFormMaxWidth,
                 ),
-                padding: const EdgeInsets.all(
-                  Constants.spacingMiddle,
-                ),
+                padding: const EdgeInsets.all(Constants.spacingMiddle),
                 child: const Column(
                   mainAxisAlignment: MainAxisAlignment.start,
                   crossAxisAlignment: CrossAxisAlignment.start,
@@ -74,6 +72,10 @@ class _SettingsState extends State<Settings> {
                     /// user can update his email address and password or delete
                     /// his account.
                     SettingsProfile(),
+
+                    /// Display the app settings. Here the user can customize
+                    /// the app and import / export data.
+                    SettingsAppSettings(),
 
                     /// Display some general information about the app, like the
                     /// version and the link to our website.

--- a/app/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/app/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -8,6 +8,7 @@ import Foundation
 import app_links
 import audio_service
 import audio_session
+import file_picker
 import just_audio
 import media_kit_libs_macos_video
 import media_kit_video
@@ -27,6 +28,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AppLinksMacosPlugin.register(with: registry.registrar(forPlugin: "AppLinksMacosPlugin"))
   AudioServicePlugin.register(with: registry.registrar(forPlugin: "AudioServicePlugin"))
   AudioSessionPlugin.register(with: registry.registrar(forPlugin: "AudioSessionPlugin"))
+  FilePickerPlugin.register(with: registry.registrar(forPlugin: "FilePickerPlugin"))
   JustAudioPlugin.register(with: registry.registrar(forPlugin: "JustAudioPlugin"))
   MediaKitLibsMacosVideoPlugin.register(with: registry.registrar(forPlugin: "MediaKitLibsMacosVideoPlugin"))
   MediaKitVideoPlugin.register(with: registry.registrar(forPlugin: "MediaKitVideoPlugin"))

--- a/app/macos/Podfile.lock
+++ b/app/macos/Podfile.lock
@@ -5,6 +5,8 @@ PODS:
     - FlutterMacOS
   - audio_session (0.0.1):
     - FlutterMacOS
+  - file_picker (0.0.1):
+    - FlutterMacOS
   - FlutterMacOS (1.0.0)
   - just_audio (0.0.1):
     - Flutter
@@ -49,6 +51,7 @@ DEPENDENCIES:
   - app_links (from `Flutter/ephemeral/.symlinks/plugins/app_links/macos`)
   - audio_service (from `Flutter/ephemeral/.symlinks/plugins/audio_service/macos`)
   - audio_session (from `Flutter/ephemeral/.symlinks/plugins/audio_session/macos`)
+  - file_picker (from `Flutter/ephemeral/.symlinks/plugins/file_picker/macos`)
   - FlutterMacOS (from `Flutter/ephemeral`)
   - just_audio (from `Flutter/ephemeral/.symlinks/plugins/just_audio/darwin`)
   - media_kit_libs_macos_video (from `Flutter/ephemeral/.symlinks/plugins/media_kit_libs_macos_video/macos`)
@@ -78,6 +81,8 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/audio_service/macos
   audio_session:
     :path: Flutter/ephemeral/.symlinks/plugins/audio_session/macos
+  file_picker:
+    :path: Flutter/ephemeral/.symlinks/plugins/file_picker/macos
   FlutterMacOS:
     :path: Flutter/ephemeral
   just_audio:
@@ -115,6 +120,7 @@ SPEC CHECKSUMS:
   app_links: afe860c55c7ef176cea7fb630a2b7d7736de591d
   audio_service: 0d9e4e25347bb3efb768f3b9f005911a81e587a7
   audio_session: 48ab6500f7a5e7c64363e206565a5dfe5a0c1441
+  file_picker: 7584aae6fa07a041af2b36a2655122d42f578c1a
   FlutterMacOS: 8f6f14fa908a6fb3fba0cd85dbd81ec4b251fb24
   just_audio: 4e391f57b79cad2b0674030a00453ca5ce817eed
   media_kit_libs_macos_video: 85a23e549b5f480e72cae3e5634b5514bc692f65

--- a/app/macos/Runner/DebugProfile.entitlements
+++ b/app/macos/Runner/DebugProfile.entitlements
@@ -10,6 +10,8 @@
 	<true/>
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
+	<key>com.apple.security.files.user-selected.read-write</key>
+	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
 	<key>com.apple.security.network.server</key>

--- a/app/macos/Runner/Release.entitlements
+++ b/app/macos/Runner/Release.entitlements
@@ -8,6 +8,8 @@
 	</array>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
+	<key>com.apple.security.files.user-selected.read-write</key>
+	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
 	<key>com.apple.security.network.server</key>

--- a/app/macos/Runner/RunnerDebug.entitlements
+++ b/app/macos/Runner/RunnerDebug.entitlements
@@ -10,6 +10,8 @@
 	<true/>
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
+	<key>com.apple.security.files.user-selected.read-write</key>
+	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
 	<key>com.apple.security.network.server</key>

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -185,6 +185,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.0"
+  cross_file:
+    dependency: transitive
+    description:
+      name: cross_file
+      sha256: "7caf6a750a0c04effbb52a676dce9a4a592e10ad35c34d6d2d0e4811160d5670"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.4+2"
   crypto:
     dependency: "direct main"
     description:
@@ -245,10 +253,10 @@ packages:
     dependency: transitive
     description:
       name: ffi
-      sha256: "493f37e7df1804778ff3a53bd691d8692ddf69702cf4c1c1096a2e41b4779e21"
+      sha256: "289279317b4b16eb2bb7e271abccd4bf84ec9bdcbe999e278a94b804f5630418"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
   file:
     dependency: transitive
     description:
@@ -257,6 +265,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.0"
+  file_picker:
+    dependency: "direct main"
+    description:
+      name: file_picker
+      sha256: "8986dec4581b4bcd4b6df5d75a2ea0bede3db802f500635d05fa8be298f9467f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.1.2"
   fixnum:
     dependency: transitive
     description:
@@ -310,6 +326,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.4.5"
+  flutter_plugin_android_lifecycle:
+    dependency: transitive
+    description:
+      name: flutter_plugin_android_lifecycle
+      sha256: f948e346c12f8d5480d2825e03de228d0eb8c3a737e4cdaa122267b89c022b5e
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.28"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -692,10 +716,10 @@ packages:
     dependency: transitive
     description:
       name: path_provider
-      sha256: fec0d61223fba3154d87759e3cc27fe2c8dc498f6386c6d6fc80d1afdd1bf378
+      sha256: "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.1.5"
   path_provider_android:
     dependency: transitive
     description:
@@ -1321,10 +1345,10 @@ packages:
     dependency: transitive
     description:
       name: win32
-      sha256: "015002c060f1ae9f41a818f2d5640389cc05283e368be19dc8d77cecb43c40c9"
+      sha256: dc6ecaa00a7c708e5b4d10ee7bec8c270e9276dfcab1783f57e9962d7884305f
       url: "https://pub.dev"
     source: hosted
-    version: "5.5.3"
+    version: "5.12.0"
   window_manager:
     dependency: "direct main"
     description:
@@ -1342,7 +1366,7 @@ packages:
     source: hosted
     version: "1.0.4"
   xml:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: xml
       sha256: b015a8ad1c488f66851d762d3090a21c600e479dc75e68328c52774040cf9226
@@ -1374,5 +1398,5 @@ packages:
     source: hosted
     version: "2.3.10"
 sdks:
-  dart: ">=3.7.0-0 <4.0.0"
-  flutter: ">=3.24.0"
+  dart: ">=3.7.0 <4.0.0"
+  flutter: ">=3.27.0"

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -42,6 +42,7 @@ dependencies:
   carousel_slider: ^5.0.0
   collection: ^1.17.0
   crypto: ^3.0.6
+  file_picker: ^10.1.2
   flutter_cache_manager: ^3.4.0
   flutter_markdown: ^0.7.6
   flutter_native_splash: ^2.4.5
@@ -68,6 +69,7 @@ dependencies:
   url_launcher: ^6.3.1
   web: ^1.1.1
   window_manager: ^0.4.3
+  xml: ^6.5.0
   youtube_explode_dart: ^2.3.10
 
 dev_dependencies:

--- a/app/run.sh
+++ b/app/run.sh
@@ -43,7 +43,11 @@ set -o allexport && source "../supabase/.env.${environment}" && set +o allexport
 # uses the Docker address of the Supabase instance.
 supabase_url=$FEEDDECK_SUPABASE_URL
 if [ "${environment}" == "local" ]; then
-  supabase_url="http://localhost:54321"
+  if [ "${device}" == "sdk gphone arm64" ]; then
+    supabase_url="http://10.0.2.2:54321"
+  else
+    supabase_url="http://localhost:54321"
+  fi
 fi
 
 # If the selected device is "chrome" we have to add some additional flags to the


### PR DESCRIPTION
It is now possible import and export decks. Decks can be imported from
OPML files. For each import a new deck is created. If the OPML file
contains nested `outline` tags, we will create one column for each
parent `outline` tag. Otherwise we will create a column named `Unknown`
and all sources to this column. When a deck is exported we will create
one `outline` tag for each column with it's sources as siblings.

Closes #229

<!--
  Keep PR title verbose enough and add prefix telling about what source it touches e.g "[rss] Add feature xyz" or if the
  the PR is not realated to a source use "[core]", e.g. "[core] Fix xyz".

  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
