### PR TITLE
Remove Drag Handles from Sources

### DIFF
--- a/app/lib/widgets/source/source_list_item.dart
+++ b/app/lib/widgets/source/source_list_item.dart
@@ -110,57 +110,64 @@ class _SourceListItemState extends State<SourceListItem> {
 
   @override
   Widget build(BuildContext context) {
-    return Card(
-      color: Constants.secondary,
-      margin: const EdgeInsets.only(bottom: Constants.spacingSmall),
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          Padding(
-            padding: const EdgeInsets.all(Constants.spacingMiddle),
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        Characters(widget.source.title)
-                            .replaceAll(Characters(''), Characters('\u{200B}'))
-                            .toString(),
-                        maxLines: 1,
-                        style: const TextStyle(overflow: TextOverflow.ellipsis),
-                      ),
-                      Text(
-                        Characters(widget.source.type.toLocalizedString())
-                            .replaceAll(Characters(''), Characters('\u{200B}'))
-                            .toString(),
-                        maxLines: 1,
-                        style: const TextStyle(
-                          overflow: TextOverflow.ellipsis,
-                          fontSize: 10.0,
+    return ReorderableDragStartListener(
+      index: widget.sourceIndex,
+      child: Card(
+        color: Constants.secondary,
+        margin: const EdgeInsets.only(bottom: Constants.spacingSmall),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Padding(
+              padding: const EdgeInsets.all(Constants.spacingMiddle),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          Characters(widget.source.title)
+                              .replaceAll(
+                                Characters(''),
+                                Characters('\u{200B}'),
+                              )
+                              .toString(),
+                          maxLines: 1,
+                          style: const TextStyle(
+                            overflow: TextOverflow.ellipsis,
+                          ),
                         ),
-                      ),
-                    ],
+                        Text(
+                          Characters(widget.source.type.toLocalizedString())
+                              .replaceAll(
+                                Characters(''),
+                                Characters('\u{200B}'),
+                              )
+                              .toString(),
+                          maxLines: 1,
+                          style: const TextStyle(
+                            overflow: TextOverflow.ellipsis,
+                            fontSize: 10.0,
+                          ),
+                        ),
+                      ],
+                    ),
                   ),
-                ),
-                IconButton(
-                  onPressed: () => _showDeleteDialog(),
-                  icon:
-                      _isLoading
-                          ? const ElevatedButtonProgressIndicator()
-                          : const Icon(Icons.delete),
-                ),
-                ReorderableDragStartListener(
-                  index: widget.sourceIndex,
-                  child: Icon(Icons.drag_handle),
-                ),
-              ],
+                  IconButton(
+                    onPressed: () => _showDeleteDialog(),
+                    icon:
+                        _isLoading
+                            ? const ElevatedButtonProgressIndicator()
+                            : const Icon(Icons.delete),
+                  ),
+                ],
+              ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
Remove the drag handle icon from the sources. The icon was used together
with the `ReorderableDragStartListener` widget to sort the sources. This
can now be done without the icon, because we wrap the source card widget
within the `ReorderableDragStartListener` widget.

<!--
  Keep PR title verbose enough and add prefix telling about what source it touches e.g "[rss] Add feature xyz" or if the
  the PR is not realated to a source use "[core]", e.g. "[core] Fix xyz".

  If you add a breaking change within your PR you should add ":warning:" to the title,
  e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
